### PR TITLE
Fix cancellation flow for video generation

### DIFF
--- a/src/backend/api/routes/videos.py
+++ b/src/backend/api/routes/videos.py
@@ -23,6 +23,7 @@ from backend.api.responses import (
 )
 from backend.api.sse import stream_progress_events
 from backend.video_summary.infrastructure.runtime import AsrModelNotReadyError
+from backend.video_summary.generation.usecases.generate_summary import GenerateCancelledError
 from backend.video_summary.library.usecases.mutations import GenerationInProgressError
 from backend.video_summary.library.usecases.summary_generation import DuplicateSeriesGenerationError
 
@@ -198,11 +199,16 @@ async def generate_video_summary(
         )
     except AsrModelNotReadyError as error:
         raise HTTPException(status_code=409, detail=str(error)) from error
+    except GenerateCancelledError as error:
+        raise HTTPException(status_code=409, detail="generation cancelled") from error
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     except RuntimeError as error:
         raise HTTPException(status_code=503, detail=str(error)) from error
     if video_summary is None:
+        snapshot = container.generation_progress_tracker.get_snapshot(_build_task_id(series_id, video_id))
+        if snapshot.status == "cancelled":
+            raise HTTPException(status_code=409, detail="generation cancelled")
         raise HTTPException(status_code=404, detail=f"video not found '{series_id}/{video_id}'")
     return video_summary.summary
 
@@ -379,7 +385,6 @@ def get_video_generation_status(
     video_id: str,
     container: ApiContainerDep,
 ) -> dict[str, object]:
-    _ensure_video_exists(container, series_id, video_id)
     task_id = _build_task_id(series_id, video_id)
     return {
         "task_id": task_id,

--- a/src/backend/video_summary/generation/cancellation.py
+++ b/src/backend/video_summary/generation/cancellation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass, field
+from typing import Callable, Protocol
+
+
+class CancellableHandle(Protocol):
+    @property
+    def kind(self) -> str: ...
+    def cancel(self) -> None: ...
+
+
+@dataclass
+class ProcessHandle:
+    kind: str = field(default="process", init=False)
+    _proc: object = field(repr=False)
+
+    def cancel(self) -> None:
+        try:
+            self._proc.kill()  # type: ignore[attr-defined]
+        except OSError:
+            pass
+
+
+@dataclass
+class TaskHandle:
+    kind: str = field(default="task", init=False)
+    _task: asyncio.Task  # type: ignore[type-arg]
+
+    def cancel(self) -> None:
+        self._task.cancel()
+
+
+class GenerationCancellationContext:
+    def __init__(self, task_id: str) -> None:
+        self.task_id = task_id
+        self._cancel_event = threading.Event()
+        self._lock = threading.Lock()
+        self._handles: list[CancellableHandle] = []
+
+    @property
+    def cancel_requested(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def request_cancel(self) -> None:
+        self._cancel_event.set()
+        with self._lock:
+            handles = list(self._handles)
+        for handle in handles:
+            handle.cancel()
+
+    def register(self, handle: CancellableHandle) -> None:
+        with self._lock:
+            self._handles.append(handle)
+
+    def unregister(self, handle: CancellableHandle) -> None:
+        with self._lock:
+            try:
+                self._handles.remove(handle)
+            except ValueError:
+                pass
+
+
+async def cancellable_await(
+    coro: object,
+    ctx: GenerationCancellationContext,
+) -> object:
+    """Wrap an awaitable so that a cancel request aborts the asyncio Task immediately."""
+    from backend.video_summary.generation.usecases.generate_summary import GenerateCancelledError
+
+    if ctx.cancel_requested:
+        raise GenerateCancelledError("任务已取消")
+
+    task: asyncio.Task = asyncio.ensure_future(coro)  # type: ignore[arg-type]
+    handle = TaskHandle(_task=task)
+    ctx.register(handle)
+    try:
+        return await task
+    except asyncio.CancelledError:
+        raise GenerateCancelledError("任务已取消")
+    finally:
+        ctx.unregister(handle)

--- a/src/backend/video_summary/generation/ports.py
+++ b/src/backend/video_summary/generation/ports.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Protocol
+from typing import TYPE_CHECKING, Callable, Protocol
 
 from backend.video_summary.domain.models import SummaryDocument, Transcript, VideoAsset
+
+if TYPE_CHECKING:
+    from backend.video_summary.generation.cancellation import GenerationCancellationContext
 
 
 class MediaProcessor(Protocol):
     def probe_duration(self, video_path: Path) -> float:
         ...
 
-    def extract_audio(self, video_path: Path, audio_path: Path) -> Path:
+    def extract_audio(
+        self,
+        video_path: Path,
+        audio_path: Path,
+        cancellation: "GenerationCancellationContext | None" = None,
+    ) -> Path:
         ...
 
 
@@ -29,6 +37,7 @@ class Summarizer(Protocol):
         self,
         video: VideoAsset,
         transcript: Transcript,
+        cancellation: "GenerationCancellationContext | None" = None,
     ) -> SummaryDocument:
         ...
 
@@ -38,6 +47,7 @@ class TranscriptEnhancer(Protocol):
         self,
         video: VideoAsset,
         transcript: Transcript,
+        cancellation: "GenerationCancellationContext | None" = None,
     ) -> Transcript:
         ...
 

--- a/src/backend/video_summary/generation/usecases/generate_summary.py
+++ b/src/backend/video_summary/generation/usecases/generate_summary.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from pathlib import Path
 
 from backend.video_summary.domain.models import SummaryDocument, VideoAsset
+from backend.video_summary.generation.cancellation import GenerationCancellationContext
 from backend.video_summary.generation.ports import (
     GenerationArtifactStore,
     MediaProcessor,
@@ -38,6 +40,36 @@ class GenerateVideoSummary:
         video_path: Path,
         output_dir: Path,
         progress_reporter: ProgressReporter | None = None,
+        cancellation: GenerationCancellationContext | None = None,
+    ) -> SummaryDocument:
+        resolved_cancellation = cancellation
+        cancel_watch_task: asyncio.Task[None] | None = None
+        if resolved_cancellation is None and progress_reporter is not None:
+            resolved_cancellation = GenerationCancellationContext(str(output_dir))
+            cancel_watch_task = asyncio.create_task(
+                _mirror_progress_cancellation(progress_reporter, resolved_cancellation)
+            )
+
+        try:
+            return await self._run_with_cancellation(
+                video_path=video_path,
+                output_dir=output_dir,
+                progress_reporter=progress_reporter,
+                cancellation=resolved_cancellation,
+            )
+        finally:
+            if cancel_watch_task is not None:
+                cancel_watch_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await cancel_watch_task
+
+    async def _run_with_cancellation(
+        self,
+        *,
+        video_path: Path,
+        output_dir: Path,
+        progress_reporter: ProgressReporter | None,
+        cancellation: GenerationCancellationContext | None,
     ) -> SummaryDocument:
         _raise_if_cancelled(progress_reporter)
         await asyncio.to_thread(output_dir.mkdir, parents=True, exist_ok=True)
@@ -55,8 +87,9 @@ class GenerateVideoSummary:
 
         if progress_reporter is not None:
             progress_reporter.update("extract_audio", 15.0, "正在将视频转换为音频")
-        await asyncio.to_thread(self._media_processor.extract_audio, video_path, audio_path)
+        await asyncio.to_thread(self._media_processor.extract_audio, video_path, audio_path, cancellation)
         _raise_if_cancelled(progress_reporter)
+
         if progress_reporter is not None:
             progress_reporter.update("transcribe", 20.0, "正在使用 Whisper 转写音频")
         transcript = await asyncio.to_thread(
@@ -74,9 +107,12 @@ class GenerateVideoSummary:
                 progress_reporter.update("enhance_transcript", 78.0, "正在用 AI 修正转写文本")
             _raise_if_cancelled(progress_reporter)
             try:
-                transcript = await self._transcript_enhancer.enhance(video, transcript)
+                transcript = await self._transcript_enhancer.enhance(video, transcript, cancellation)
+            except GenerateCancelledError:
+                raise
             except Exception as error:
                 raise RuntimeError(_build_llm_stage_error("AI 内容增强", error)) from error
+            _raise_if_cancelled(progress_reporter)
             await self._artifact_store.save_enhanced_transcript(
                 transcript=transcript,
                 output_dir=output_dir,
@@ -94,9 +130,12 @@ class GenerateVideoSummary:
             progress_reporter.update("summarize", 88.0, "正在生成 AI 概况")
         _raise_if_cancelled(progress_reporter)
         try:
-            summary_document = await self._summarizer.summarize(video, transcript)
+            summary_document = await self._summarizer.summarize(video, transcript, cancellation)
+        except GenerateCancelledError:
+            raise
         except Exception as error:
             raise RuntimeError(_build_llm_stage_error("AI 概况生成", error)) from error
+        _raise_if_cancelled(progress_reporter)
         await self._artifact_store.save_summary_document(document=summary_document, output_dir=output_dir)
         return summary_document
 
@@ -131,6 +170,17 @@ def _handle_transcribe_progress(progress_reporter: ProgressReporter, ratio: floa
         20.0 + max(0.0, min(1.0, ratio)) * 55.0,
         "Whisper 正在转写音频",
     )
+
+
+async def _mirror_progress_cancellation(
+    progress_reporter: ProgressReporter,
+    cancellation: GenerationCancellationContext,
+) -> None:
+    while not cancellation.cancel_requested:
+        if progress_reporter.is_cancel_requested():
+            cancellation.request_cancel()
+            return
+        await asyncio.sleep(0.05)
 
 
 def _raise_if_cancelled(progress_reporter: ProgressReporter | None) -> None:

--- a/src/backend/video_summary/infrastructure/in_memory_progress_tracker.py
+++ b/src/backend/video_summary/infrastructure/in_memory_progress_tracker.py
@@ -111,6 +111,13 @@ class InMemoryProgressTracker:
         with self._lock:
             return task_id in self._cancelled_tasks
 
+    _TERMINAL_STATES = frozenset({"cancelled", "completed", "failed"})
+    _BLOCKED_WRITES: dict[str, frozenset[str]] = {
+        "cancelling": frozenset({"completed", "running"}),
+        "cancelled": frozenset({"completed", "running"}),
+        "completed": frozenset({"cancelled"}),
+    }
+
     def _write(
         self,
         task_id: str,
@@ -124,6 +131,8 @@ class InMemoryProgressTracker:
         now = time.time()
         with self._lock:
             previous = self._snapshots.get(task_id)
+            if previous is not None and status in self._BLOCKED_WRITES.get(previous.status, frozenset()):
+                return
             sequence = 0 if previous is None else previous.sequence + 1
             normalized_progress = None if progress is None else max(0.0, min(100.0, progress))
             started_at = now if previous is None else previous.started_at
@@ -211,7 +220,7 @@ class TaskProgressReporter:
 
     def raise_if_cancelled(self) -> None:
         if self.is_cancel_requested():
-            raise RuntimeError("下载已取消")
+            raise RuntimeError("任务已取消")
 
 
 def _resolve_stage_started_at(

--- a/src/backend/video_summary/infrastructure/litellm_summarizer.py
+++ b/src/backend/video_summary/infrastructure/litellm_summarizer.py
@@ -5,6 +5,7 @@ import asyncio
 from backend.shared.llm import LiteLLMCompletionGateway
 from backend.video_summary.domain.models import SummaryDocument, Transcript, VideoAsset
 from backend.video_summary.generation.ports import Summarizer
+from backend.video_summary.generation.cancellation import GenerationCancellationContext, cancellable_await
 from backend.video_summary.generation import (
     SummaryPayload,
     build_chunk_prompt,
@@ -31,7 +32,12 @@ class LiteLLMCompletionSummarizer(Summarizer):
         self._direct_summary_threshold_ratio = direct_summary_threshold_ratio
         self._summary_chunk_concurrency = max(1, summary_chunk_concurrency)
 
-    async def summarize(self, video: VideoAsset, transcript: Transcript) -> SummaryDocument:
+    async def summarize(
+        self,
+        video: VideoAsset,
+        transcript: Transcript,
+        cancellation: GenerationCancellationContext | None = None,
+    ) -> SummaryDocument:
         if _should_use_direct_summary(
             video=video,
             transcript=transcript,
@@ -39,20 +45,22 @@ class LiteLLMCompletionSummarizer(Summarizer):
             reserved_output_tokens=self._reserved_output_tokens,
             direct_summary_threshold_ratio=self._direct_summary_threshold_ratio,
         ):
-            payload = await self._gateway.acomplete_structured(
+            coro = self._gateway.acomplete_structured(
                 [{"role": "user", "content": build_transcript_document_prompt(video, transcript)}],
                 response_model=SummaryPayload,
             )
+            payload = await cancellable_await(coro, cancellation) if cancellation else await coro
             summary_data = payload.model_dump()
             markdown = render_markdown(summary_data)
             return SummaryDocument(markdown=markdown, summary_data=summary_data)
 
         chunks = list(enumerate(chunk_segments(transcript.segments), start=1))
-        chunk_summaries = await self._summarize_chunks(video, chunks)
-        payload = await self._gateway.acomplete_structured(
+        chunk_summaries = await self._summarize_chunks(video, chunks, cancellation)
+        coro = self._gateway.acomplete_structured(
             [{"role": "user", "content": build_document_prompt(video, transcript, chunk_summaries)}],
             response_model=SummaryPayload,
         )
+        payload = await cancellable_await(coro, cancellation) if cancellation else await coro
         summary_data = payload.model_dump()
         markdown = render_markdown(summary_data)
         return SummaryDocument(markdown=markdown, summary_data=summary_data)
@@ -61,14 +69,19 @@ class LiteLLMCompletionSummarizer(Summarizer):
         self,
         video: VideoAsset,
         chunks: list[tuple[int, list]],
+        cancellation: GenerationCancellationContext | None,
     ) -> list[str]:
         semaphore = asyncio.Semaphore(self._summary_chunk_concurrency)
 
         async def summarize_chunk(index: int, chunk: list) -> tuple[int, str]:
             async with semaphore:
-                summary = await self._gateway.acomplete_text(
+                if cancellation is not None and cancellation.cancel_requested:
+                    from backend.video_summary.generation.usecases.generate_summary import GenerateCancelledError
+                    raise GenerateCancelledError("任务已取消")
+                coro = self._gateway.acomplete_text(
                     [{"role": "user", "content": build_chunk_prompt(video, chunk, index)}]
                 )
+                summary = await cancellable_await(coro, cancellation) if cancellation else await coro
                 return index, summary
 
         results = await asyncio.gather(

--- a/src/backend/video_summary/infrastructure/litellm_transcript_enhancer.py
+++ b/src/backend/video_summary/infrastructure/litellm_transcript_enhancer.py
@@ -5,20 +5,33 @@ import json
 from backend.shared.llm import LiteLLMCompletionGateway
 from backend.video_summary.domain.models import Transcript, TranscriptSegment, VideoAsset
 from backend.video_summary.generation import TranscriptEnhancementPayload
+from backend.video_summary.generation.cancellation import GenerationCancellationContext, cancellable_await
 
 
 class LiteLLMTranscriptEnhancer:
     def __init__(self, gateway: LiteLLMCompletionGateway) -> None:
         self._gateway = gateway
 
-    async def enhance(self, video: VideoAsset, transcript: Transcript) -> Transcript:
+    async def enhance(
+        self,
+        video: VideoAsset,
+        transcript: Transcript,
+        cancellation: GenerationCancellationContext | None = None,
+    ) -> Transcript:
         chunks = _chunk_segments(transcript.segments)
         enhanced_segments = []
         for index, chunk in enumerate(chunks, start=1):
-            corrected_payload = await self._gateway.acomplete_structured(
+            if cancellation is not None and cancellation.cancel_requested:
+                from backend.video_summary.generation.usecases.generate_summary import GenerateCancelledError
+                raise GenerateCancelledError("任务已取消")
+            coro = self._gateway.acomplete_structured(
                 [{"role": "user", "content": _build_transcript_enhancement_prompt(video, chunk, index, len(chunks))}],
                 response_model=TranscriptEnhancementPayload,
             )
+            if cancellation is not None:
+                corrected_payload = await cancellable_await(coro, cancellation)
+            else:
+                corrected_payload = await coro
             enhanced_segments.extend(_parse_corrected_segments(corrected_payload, chunk))
 
         return Transcript(

--- a/src/backend/video_summary/infrastructure/media_tools.py
+++ b/src/backend/video_summary/infrastructure/media_tools.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from backend.video_summary.generation.cancellation import GenerationCancellationContext, ProcessHandle
+
 
 class FfmpegMediaProcessor:
     def probe_duration(self, video_path: Path) -> float:
@@ -25,9 +27,14 @@ class FfmpegMediaProcessor:
         )
         return float(result.stdout.strip())
 
-    def extract_audio(self, video_path: Path, audio_path: Path) -> Path:
+    def extract_audio(
+        self,
+        video_path: Path,
+        audio_path: Path,
+        cancellation: GenerationCancellationContext | None = None,
+    ) -> Path:
         audio_path.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
+        proc = subprocess.Popen(
             [
                 "ffmpeg",
                 "-y",
@@ -42,8 +49,19 @@ class FfmpegMediaProcessor:
                 "pcm_s16le",
                 str(audio_path),
             ],
-            check=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+        if cancellation is not None:
+            handle = ProcessHandle(_proc=proc)
+            cancellation.register(handle)
+            try:
+                proc.wait()
+            finally:
+                cancellation.unregister(handle)
+        else:
+            proc.wait()
+
+        if proc.returncode != 0 and not (cancellation is not None and cancellation.cancel_requested):
+            raise subprocess.CalledProcessError(proc.returncode, "ffmpeg")
         return audio_path

--- a/src/frontend/src/features/workspace/model/workspaceContentActions.js
+++ b/src/frontend/src/features/workspace/model/workspaceContentActions.js
@@ -28,6 +28,13 @@ export function getPendingVideosForSeriesGeneration(library, seriesId) {
   return series?.videos?.filter((video) => !video.processed && video.status !== "linked" && !video.isLinked) ?? [];
 }
 
+function isGenerationCancelledError(error) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.message.includes("generation cancelled");
+}
+
 export function createWorkspaceContentActions({ state, dispatch, selectedVideo }) {
   async function reloadWorkspaceLibrary() {
     const library = await loadWorkspaceLibrary();
@@ -86,6 +93,23 @@ export function createWorkspaceContentActions({ state, dispatch, selectedVideo }
         summary: summaryResult,
       });
     } catch (error) {
+      if (isGenerationCancelledError(error)) {
+        dispatch({
+          type: "generation_cancelled",
+          taskKey: buildVideoGenerationTaskKey(seriesId, videoId),
+          mode: "video",
+          seriesId,
+          videoId,
+          snapshot: {
+            status: "cancelled",
+            stage: "cancelled",
+            progress: null,
+            detail: "任务已取消",
+            error: null,
+          },
+        });
+        return;
+      }
       const message = error instanceof Error ? error.message : "生成失败";
       dispatch({ type: "load_failed", message });
       dispatch({
@@ -182,6 +206,7 @@ export function createWorkspaceContentActions({ state, dispatch, selectedVideo }
       }
       const currentTask = getGenerationTaskForSelection(state);
       if (currentTask?.mode === "video" && state.selectedSeriesId && state.selectedVideoId) {
+        dispatch({ type: "video_generation_cancelling", seriesId: state.selectedSeriesId, videoId: state.selectedVideoId });
         await cancelVideoSummary(state.selectedSeriesId, state.selectedVideoId);
       }
     } catch (error) {

--- a/src/frontend/src/features/workspace/model/workspaceReducer.js
+++ b/src/frontend/src/features/workspace/model/workspaceReducer.js
@@ -73,6 +73,27 @@ function resolveSeriesQueueStatus(snapshotStatus, currentStatus) {
   return currentStatus;
 }
 
+function matchesCurrentGenerationSelection(state, action) {
+  if (action.mode === "video") {
+    return (
+      state.selectedContextType === "video" &&
+      state.selectedSeriesId === action.seriesId &&
+      state.selectedVideoId === action.videoId
+    );
+  }
+  if (action.mode === "series") {
+    return (
+      state.selectedContextType === "series" &&
+      state.selectedSeriesId === action.seriesId
+    );
+  }
+  return false;
+}
+
+function isTerminalGenerationStatus(status) {
+  return status === "completed" || status === "failed" || status === "cancelled";
+}
+
 export { createInitialWorkspaceState };
 
 export function workspaceReducer(state, action) {
@@ -665,6 +686,21 @@ export function workspaceReducer(state, action) {
         ),
         error: "",
       };
+    case "video_generation_cancelling": {
+      const taskKey = buildVideoGenerationTaskKey(action.seriesId, action.videoId);
+      const existing = state.generationTasksByKey?.[taskKey];
+      if (!existing) return state;
+      return {
+        ...state,
+        generationTasksByKey: setGenerationTaskForKey(
+          state.generationTasksByKey,
+          createGenerationTaskRecord({
+            ...existing,
+            snapshot: { ...(existing.snapshot ?? {}), status: "cancelling", detail: "正在停止当前任务" },
+          }),
+        ),
+      };
+    }
     case "series_generation_queue_started":
       return {
         ...state,
@@ -769,10 +805,26 @@ export function workspaceReducer(state, action) {
     case "generation_progress_updated":
       {
         const boundedProgress = action.progress == null ? null : Math.max(0, Math.min(100, action.progress));
+        const isCurrentSelection = matchesCurrentGenerationSelection(state, action);
+        const isTerminal = isTerminalGenerationStatus(action.snapshot?.status);
         const nextState = {
           ...state,
-          generationProgress: boundedProgress,
-          generationSnapshot: action.snapshot,
+          generatingVideoKey:
+            isCurrentSelection && isTerminal && action.mode === "video"
+              ? null
+              : state.generatingVideoKey,
+          generatingSeriesId:
+            isCurrentSelection && isTerminal && action.mode === "series"
+              ? null
+              : state.generatingSeriesId,
+          generationMode:
+            isCurrentSelection && isTerminal
+              ? null
+              : state.generationMode,
+          generationProgress:
+            isCurrentSelection && isTerminal ? null : boundedProgress,
+          generationSnapshot:
+            isCurrentSelection && isTerminal ? null : action.snapshot,
           generationTasksByKey: setGenerationTaskForKey(
             state.generationTasksByKey,
             createGenerationTaskRecord({
@@ -799,24 +851,55 @@ export function workspaceReducer(state, action) {
             completed,
             detail: action.snapshot?.detail ?? state.seriesGenerationQueue.detail,
             status: resolveSeriesQueueStatus(action.snapshot?.status, state.seriesGenerationQueue.status),
+            currentVideoId: isTerminal ? null : state.seriesGenerationQueue.currentVideoId,
+            currentVideoTitle: isTerminal ? null : state.seriesGenerationQueue.currentVideoTitle,
           },
         };
       }
     case "generation_status_loaded":
-      return {
-        ...state,
-        generationTasksByKey: setGenerationTaskForKey(
-          state.generationTasksByKey,
-          createGenerationTaskRecord({
-            taskKey: action.taskKey,
-            mode: action.mode,
-            seriesId: action.seriesId,
-            videoId: action.videoId ?? null,
-            snapshot: action.snapshot,
-            subscriptionActive: Boolean(action.subscriptionActive),
-          }),
-        ),
-      };
+      {
+        const isTerminal = isTerminalGenerationStatus(action.snapshot?.status);
+        const isCurrentSelection = matchesCurrentGenerationSelection(state, action);
+        return {
+          ...state,
+          generatingVideoKey:
+            isTerminal && isCurrentSelection && action.mode === "video"
+              ? null
+              : state.generatingVideoKey,
+          generatingSeriesId:
+            isTerminal && isCurrentSelection && action.mode === "series"
+              ? null
+              : state.generatingSeriesId,
+          generationMode:
+            isTerminal && isCurrentSelection ? null : state.generationMode,
+          generationProgress:
+            isTerminal && isCurrentSelection ? null : state.generationProgress,
+          generationSnapshot:
+            isTerminal && isCurrentSelection ? null : state.generationSnapshot,
+          seriesGenerationQueue:
+            action.mode === "series" &&
+            state.seriesGenerationQueue?.seriesId === action.seriesId &&
+            isTerminal
+              ? {
+                  ...state.seriesGenerationQueue,
+                  status: action.snapshot?.status ?? state.seriesGenerationQueue.status,
+                  currentVideoId: null,
+                  currentVideoTitle: null,
+                }
+              : state.seriesGenerationQueue,
+          generationTasksByKey: setGenerationTaskForKey(
+            state.generationTasksByKey,
+            createGenerationTaskRecord({
+              taskKey: action.taskKey,
+              mode: action.mode,
+              seriesId: action.seriesId,
+              videoId: action.videoId ?? null,
+              snapshot: action.snapshot,
+              subscriptionActive: Boolean(action.subscriptionActive),
+            }),
+          ),
+        };
+      }
     case "generation_cancelled":
       return {
         ...state,
@@ -825,6 +908,15 @@ export function workspaceReducer(state, action) {
         generationMode: null,
         generationProgress: null,
         generationSnapshot: null,
+        seriesGenerationQueue:
+          action.mode === "series" && state.seriesGenerationQueue?.seriesId === action.seriesId
+            ? {
+                ...state.seriesGenerationQueue,
+                status: "cancelled",
+                currentVideoId: null,
+                currentVideoTitle: null,
+              }
+            : state.seriesGenerationQueue,
         generationTasksByKey: setGenerationTaskForKey(
           state.generationTasksByKey,
           createGenerationTaskRecord({

--- a/src/frontend/src/features/workspace/ui/WorkspaceGenerationOverlay.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceGenerationOverlay.jsx
@@ -117,14 +117,15 @@ export function WorkspaceGenerationOverlay({
               );
             })}
           </div>
-          {typeof onCancel === "function" && generationSnapshot?.status === "running" ? (
+          {typeof onCancel === "function" && (generationSnapshot?.status === "running" || generationSnapshot?.status === "cancelling") ? (
             <button
               type="button"
               onClick={onCancel}
-              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-red-200 bg-white px-4 py-2.5 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 dark:border-red-900/70 dark:bg-stone-900 dark:text-red-300 dark:hover:bg-red-950/30"
+              disabled={generationSnapshot?.status === "cancelling"}
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-red-200 bg-white px-4 py-2.5 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-red-900/70 dark:bg-stone-900 dark:text-red-300 dark:hover:bg-red-950/30"
             >
               <X size={16} />
-              {cancelLabel}
+              {generationSnapshot?.status === "cancelling" ? "正在停止..." : cancelLabel}
             </button>
           ) : null}
         </div>

--- a/tests/backend/integration/api/test_generation_status_api.py
+++ b/tests/backend/integration/api/test_generation_status_api.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 
 from backend.api.app import create_app
+from backend.video_summary.generation.usecases.generate_summary import GenerateCancelledError
 from backend.video_summary.infrastructure.in_memory_progress_tracker import InMemoryProgressTracker
 from backend.video_summary.library.usecases.summary_generation import DuplicateSeriesGenerationError
 
@@ -40,6 +41,21 @@ class GenerationStatusApiTests(unittest.TestCase):
         self.assertEqual(payload["snapshot"]["status"], "running")
         self.assertEqual(payload["snapshot"]["stage"], "summarize")
         self.assertEqual(payload["snapshot"]["progress"], 88.0)
+
+    def test_video_generation_status_does_not_require_existing_video_source(self) -> None:
+        tracker = InMemoryProgressTracker()
+        reporter = tracker.create_reporter("series-1/video-1")
+        reporter.cancelled("任务已取消")
+        container = _build_container(tracker)
+        container.get_video_source = SimpleNamespace(run=lambda series_id, video_id: None)
+        client = TestClient(create_app(container))
+
+        response = client.get("/api/videos/series-1/video-1/generate/status")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["task_id"], "series-1/video-1")
+        self.assertEqual(payload["snapshot"]["status"], "cancelled")
 
     def test_series_generation_status_returns_running_snapshot(self) -> None:
         tracker = InMemoryProgressTracker()
@@ -83,6 +99,24 @@ class GenerationStatusApiTests(unittest.TestCase):
         self.assertTrue(tracker.is_cancel_requested("series-1/video-1"))
         self.assertTrue(tracker.is_cancel_requested("series-1/video-2"))
 
+    def test_video_generate_returns_conflict_when_generation_is_cancelled(self) -> None:
+        tracker = InMemoryProgressTracker()
+        reporter = tracker.create_reporter("series-1/video-1")
+        reporter.cancelled("任务已取消")
+        container = _build_container(tracker)
+
+        async def _cancelled_generate(series_id: str, video_id: str, transcript_enhancement_enabled=None):
+            del series_id, video_id, transcript_enhancement_enabled
+            raise GenerateCancelledError("任务已取消")
+
+        container.generate_video_summary = SimpleNamespace(run=_cancelled_generate)
+        client = TestClient(create_app(container))
+
+        response = client.post("/api/videos/series-1/video-1/generate")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["detail"], "generation cancelled")
+
     def test_sse_progress_stream_emits_current_snapshot_immediately(self) -> None:
         tracker = InMemoryProgressTracker()
         reporter = tracker.create_reporter("series-1/video-1")
@@ -104,6 +138,7 @@ def _build_container(tracker: InMemoryProgressTracker):
         root_dir=None,
         generation_progress_tracker=tracker,
         get_video_source=source_runner,
+        generate_video_summary=SimpleNamespace(run=lambda series_id, video_id, transcript_enhancement_enabled=None: None),
         generate_series_summaries=SimpleNamespace(run=lambda series_id, transcript_enhancement_enabled=None: None),
     )
 

--- a/tests/backend/unit/generation/test_generate_summary_cancellation.py
+++ b/tests/backend/unit/generation/test_generate_summary_cancellation.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from backend.video_summary.domain.models import SummaryDocument, Transcript, VideoAsset
+from backend.video_summary.generation.cancellation import GenerationCancellationContext
+from backend.video_summary.generation.usecases.generate_summary import GenerateCancelledError, GenerateVideoSummary
+
+
+class FakeArtifactStore:
+    def __init__(self) -> None:
+        self.saved_enhanced: list = []
+        self.saved_cleaned: list = []
+        self.saved_summary: list = []
+
+    async def save_enhanced_transcript(self, *, transcript, output_dir) -> None:
+        self.saved_enhanced.append(transcript)
+
+    async def save_cleaned_transcript(self, *, video, transcript, output_dir) -> None:
+        self.saved_cleaned.append(transcript)
+
+    async def save_summary_document(self, *, document, output_dir) -> None:
+        self.saved_summary.append(document)
+
+
+class FakeMediaProcessor:
+    def __init__(self, kill_event: asyncio.Event | None = None) -> None:
+        self.kill_called = False
+        self._kill_event = kill_event
+
+    def probe_duration(self, video_path: Path) -> float:
+        return 10.0
+
+    def extract_audio(self, video_path: Path, audio_path: Path, cancellation=None) -> Path:
+        if cancellation is not None:
+            proc = MagicMock()
+            proc.returncode = -9
+
+            def fake_wait():
+                if cancellation.cancel_requested:
+                    self.kill_called = True
+
+            proc.wait = fake_wait
+            from backend.video_summary.generation.cancellation import ProcessHandle
+            handle = ProcessHandle(_proc=proc)
+            cancellation.register(handle)
+            try:
+                cancellation._cancel_event.wait(timeout=0.1)
+                self.kill_called = True
+            finally:
+                cancellation.unregister(handle)
+        return audio_path
+
+
+class FakeTranscriber:
+    def transcribe(self, audio_path, output_stem, on_progress=None) -> Transcript:
+        return Transcript(language="zh", segments=[])
+
+
+class FakeEnhancer:
+    def __init__(self, chunks: int = 2) -> None:
+        self._chunks = chunks
+        self.calls = 0
+
+    async def enhance(self, video, transcript, cancellation=None) -> Transcript:
+        for i in range(self._chunks):
+            if cancellation is not None and cancellation.cancel_requested:
+                raise GenerateCancelledError("任务已取消")
+            self.calls += 1
+            await asyncio.sleep(0)
+        return transcript
+
+
+class FakeSummarizer:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def summarize(self, video, transcript, cancellation=None) -> SummaryDocument:
+        if cancellation is not None and cancellation.cancel_requested:
+            raise GenerateCancelledError("任务已取消")
+        self.calls += 1
+        return SummaryDocument(markdown="# Test", summary_data={"title": "Test"})
+
+
+class GenerateVideoSummaryCancellationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_extract_audio_cancel_raises_generate_cancelled(self) -> None:
+        cancellation = GenerationCancellationContext("series-1/video-1")
+        media = FakeMediaProcessor()
+        use_case = GenerateVideoSummary(
+            media_processor=media,
+            transcriber=FakeTranscriber(),
+            transcript_enhancer=None,
+            summarizer=FakeSummarizer(),
+            artifact_store=FakeArtifactStore(),
+        )
+
+        async def cancel_soon():
+            await asyncio.sleep(0.01)
+            cancellation.request_cancel()
+
+        video_path = Path("fake_video.mp4")
+        output_dir = Path("fake_output")
+
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            asyncio.create_task(cancel_soon())
+            cancellation.request_cancel()
+            with self.assertRaises(GenerateCancelledError):
+                from backend.video_summary.infrastructure.in_memory_progress_tracker import InMemoryProgressTracker
+                tracker = InMemoryProgressTracker()
+                reporter = tracker.create_reporter("series-1/video-1")
+                tracker.request_cancel("series-1/video-1")
+                await use_case.run(video_path, output_dir, reporter, cancellation)
+
+    async def test_enhance_transcript_cancel_between_chunks_does_not_save(self) -> None:
+        cancellation = GenerationCancellationContext("series-1/video-1")
+        enhancer = FakeEnhancer(chunks=3)
+        store = FakeArtifactStore()
+
+        class CancelAfterFirstChunkEnhancer:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def enhance(self, video, transcript, cancellation=None):
+                for i in range(3):
+                    if cancellation is not None and cancellation.cancel_requested:
+                        raise GenerateCancelledError("任务已取消")
+                    self.calls += 1
+                    if self.calls == 1:
+                        cancellation.request_cancel()
+                    await asyncio.sleep(0)
+                return transcript
+
+        cancel_enhancer = CancelAfterFirstChunkEnhancer()
+        use_case = GenerateVideoSummary(
+            media_processor=FakeMediaProcessor(),
+            transcriber=FakeTranscriber(),
+            transcript_enhancer=cancel_enhancer,
+            summarizer=FakeSummarizer(),
+            artifact_store=store,
+        )
+
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            with self.assertRaises(GenerateCancelledError):
+                await use_case.run(Path("v.mp4"), Path("out"), cancellation=cancellation)
+
+        self.assertEqual(cancel_enhancer.calls, 1)
+        self.assertEqual(store.saved_enhanced, [])
+        self.assertEqual(store.saved_summary, [])
+
+    async def test_summarize_cancel_does_not_save_summary(self) -> None:
+        cancellation = GenerationCancellationContext("series-1/video-1")
+        store = FakeArtifactStore()
+
+        class CancelSummarizer:
+            async def summarize(self, video, transcript, cancellation=None):
+                if cancellation is not None:
+                    cancellation.request_cancel()
+                raise GenerateCancelledError("任务已取消")
+
+        use_case = GenerateVideoSummary(
+            media_processor=FakeMediaProcessor(),
+            transcriber=FakeTranscriber(),
+            transcript_enhancer=None,
+            summarizer=CancelSummarizer(),
+            artifact_store=store,
+        )
+
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            with self.assertRaises(GenerateCancelledError):
+                await use_case.run(Path("v.mp4"), Path("out"), cancellation=cancellation)
+
+        self.assertEqual(store.saved_summary, [])
+
+    async def test_cancelled_error_is_not_wrapped_as_runtime_error(self) -> None:
+        """GenerateCancelledError must not be swallowed by the except Exception branch."""
+        cancellation = GenerationCancellationContext("series-1/video-1")
+
+        class AlwaysCancelSummarizer:
+            async def summarize(self, video, transcript, cancellation=None):
+                raise GenerateCancelledError("取消")
+
+        use_case = GenerateVideoSummary(
+            media_processor=FakeMediaProcessor(),
+            transcriber=FakeTranscriber(),
+            transcript_enhancer=None,
+            summarizer=AlwaysCancelSummarizer(),
+            artifact_store=FakeArtifactStore(),
+        )
+
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            with self.assertRaises(GenerateCancelledError):
+                await use_case.run(Path("v.mp4"), Path("out"), cancellation=cancellation)
+
+
+async def _fake_to_thread(func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/backend/unit/generation/test_generation_progress_tracker.py
+++ b/tests/backend/unit/generation/test_generation_progress_tracker.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import sys
 import unittest
-from pathlib import Path
-
 
 from backend.video_summary.infrastructure.in_memory_progress_tracker import InMemoryProgressTracker
 
@@ -56,6 +53,38 @@ class GenerationProgressTrackerTests(unittest.TestCase):
         self.assertGreater(running.sequence, idle.sequence)
         self.assertEqual(running.status, "running")
         reporter.completed("done")
+
+
+class TerminalStateProtectionTests(unittest.TestCase):
+    def test_completed_write_is_dropped_when_status_is_cancelling(self) -> None:
+        tracker = InMemoryProgressTracker()
+        reporter = tracker.create_reporter("series-1/video-1")
+        reporter.update("summarize", 88.0, "正在生成 AI 概况")
+        tracker.request_cancel("series-1/video-1")
+
+        reporter.completed("AI 概况已生成")
+
+        snapshot = tracker.get_snapshot("series-1/video-1")
+        self.assertEqual(snapshot.status, "cancelling")
+
+    def test_completed_write_is_dropped_when_status_is_cancelled(self) -> None:
+        tracker = InMemoryProgressTracker()
+        reporter = tracker.create_reporter("series-1/video-1")
+        tracker.request_cancel("series-1/video-1")
+        reporter.cancelled("已取消")
+
+        reporter.completed("AI 概况已生成")
+
+        snapshot = tracker.get_snapshot("series-1/video-1")
+        self.assertEqual(snapshot.status, "cancelled")
+
+    def test_raise_if_cancelled_message_is_task_cancelled(self) -> None:
+        tracker = InMemoryProgressTracker()
+        reporter = tracker.create_reporter("series-1/video-1")
+        tracker.request_cancel("series-1/video-1")
+
+        with self.assertRaisesRegex(RuntimeError, "任务已取消"):
+            reporter.raise_if_cancelled()
 
 
 if __name__ == "__main__":

--- a/tests/frontend/features/workspace/model/workspaceReducer.test.js
+++ b/tests/frontend/features/workspace/model/workspaceReducer.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { MODEL_DOWNLOAD_FAILED_MESSAGE } from "@src/features/workspace/model/modelDownloadMessages";
 import { workspaceReducer } from "@src/features/workspace/model/workspaceReducer";
+import { buildVideoGenerationTaskKey, createInitialWorkspaceState } from "@src/features/workspace/model/workspaceState";
 
 describe("workspaceReducer model download failures", () => {
   it("keeps faster-whisper download failure on the matching model", () => {
@@ -52,5 +53,41 @@ describe("workspaceReducer model download failures", () => {
       progress: null,
       error: MODEL_DOWNLOAD_FAILED_MESSAGE,
     });
+  });
+});
+
+describe("workspaceReducer video generation cancellation", () => {
+  it("marks video task snapshot as cancelling on video_generation_cancelling", () => {
+    const taskKey = buildVideoGenerationTaskKey("series-a", "video-1");
+    let state = workspaceReducer(createInitialWorkspaceState(), {
+      type: "generation_started",
+      videoKey: taskKey,
+      seriesId: "series-a",
+      videoId: "video-1",
+    });
+
+    state = workspaceReducer(state, {
+      type: "video_generation_cancelling",
+      seriesId: "series-a",
+      videoId: "video-1",
+    });
+
+    expect(state.generationTasksByKey[taskKey].snapshot.status).toBe("cancelling");
+    expect(state.generationTasksByKey[taskKey].snapshot.detail).toBe("正在停止当前任务");
+  });
+
+  it("series_generation_queue_cancelling sets queue status to cancelling", () => {
+    let state = workspaceReducer(createInitialWorkspaceState(), {
+      type: "series_generation_queue_started",
+      seriesId: "series-a",
+      total: 3,
+    });
+
+    state = workspaceReducer(state, {
+      type: "series_generation_queue_cancelling",
+      seriesId: "series-a",
+    });
+
+    expect(state.seriesGenerationQueue.status).toBe("cancelling");
   });
 });


### PR DESCRIPTION
Fixes #1

## Summay
- 修复无法立刻取消视频的问题
- 取消视频后，停止报错"404 not found"

## Verification
- `python -m pytest tests/backend/integration/api/test_generation_status_api.py tests/backend/unit/generation/test_generate_summary_cancellation.py tests/backend/unit/generation/test_generation_progress_tracker.py -q`
- `cd src/frontend && npm test -- --run tests/frontend/features/workspace/model/workspaceReducer.test.js`