### PR TITLE
feat: add configurable reasoning effort for LLM providers

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -19,6 +19,7 @@ mode = true
 [agent_context]
 window_tokens = 1000000
 answer_detail_level = "medium"
+reasoning_effort = "none"
 
 [agent_context.advanced]
 reserved_output_tokens = 20000

--- a/config/settings.toml.example
+++ b/config/settings.toml.example
@@ -36,6 +36,8 @@ mode = true
 window_tokens = 1000000
 # Agent 回复长度偏好。"short" 简短回答，"medium" 默认适中，"long" 适合学习复习时充分展开。
 answer_detail_level = "medium"
+# 推理模型思考强度。"none" 不传思考强度，"low" 更快，"medium" 平衡，"high" 更充分但更慢。
+reasoning_effort = "none"
 
 # Agent 上下文高级策略。
 [agent_context.advanced]

--- a/src/backend/agent/infrastructure/chat_gateway.py
+++ b/src/backend/agent/infrastructure/chat_gateway.py
@@ -16,6 +16,7 @@ class LiteLLMChatGateway(ChatGateway):
         model: str,
         base_url: str,
         api_key: str,
+        reasoning_effort: str | None = None,
         completion_fn=None,
         acompletion_fn=None,
     ) -> None:
@@ -25,6 +26,7 @@ class LiteLLMChatGateway(ChatGateway):
                 model=model,
                 base_url=base_url,
                 api_key=api_key,
+                reasoning_effort=reasoning_effort,
                 completion_fn=completion_fn,
                 acompletion_fn=acompletion_fn,
             )

--- a/src/backend/api/bootstrap.py
+++ b/src/backend/api/bootstrap.py
@@ -457,6 +457,7 @@ class LazyAgentRuntimeProvider:
                     model=env_settings.model,
                     base_url=normalize_openai_base_url(env_settings.base_url),
                     api_key=env_settings.api_key,
+                    reasoning_effort=app_settings.agent_context.reasoning_effort,
                 )
                 memory_compactor = MemoryMessageCompactor(
                     gateway=planner_gateway,

--- a/src/backend/api/contracts.py
+++ b/src/backend/api/contracts.py
@@ -29,6 +29,7 @@ class WorkspaceSettingsResponse(BaseModel):
     rag_rerank_enabled: bool
     window_tokens: int
     answer_detail_level: str = "medium"
+    reasoning_effort: str = "none"
     video_generation_concurrency: int
     web_search_enabled: bool
 
@@ -44,6 +45,7 @@ class UpdateWorkspaceSettingsRequest(BaseModel):
     rag_rerank_enabled: bool
     window_tokens: int
     answer_detail_level: str = "medium"
+    reasoning_effort: str = "none"
     video_generation_concurrency: int
     web_search_enabled: bool
 

--- a/src/backend/api/routes/settings.py
+++ b/src/backend/api/routes/settings.py
@@ -42,6 +42,7 @@ def get_workspace_settings(container: ApiContainerDep) -> WorkspaceSettingsRespo
         rag_rerank_enabled=settings.rag_rerank_enabled,
         window_tokens=settings.window_tokens,
         answer_detail_level=settings.answer_detail_level,
+        reasoning_effort=settings.reasoning_effort,
         video_generation_concurrency=settings.video_generation_concurrency,
         web_search_enabled=settings.web_search_enabled,
     )
@@ -64,6 +65,7 @@ async def update_workspace_settings(
             rag_rerank_enabled=request.rag_rerank_enabled,
             window_tokens=request.window_tokens,
             answer_detail_level=request.answer_detail_level,
+            reasoning_effort=request.reasoning_effort,
             video_generation_concurrency=request.video_generation_concurrency,
             web_search_enabled=request.web_search_enabled,
         )
@@ -86,6 +88,7 @@ async def update_workspace_settings(
         rag_rerank_enabled=settings.rag_rerank_enabled,
         window_tokens=settings.window_tokens,
         answer_detail_level=settings.answer_detail_level,
+        reasoning_effort=settings.reasoning_effort,
         video_generation_concurrency=settings.video_generation_concurrency,
         web_search_enabled=settings.web_search_enabled,
     )

--- a/src/backend/shared/llm/litellm_gateway.py
+++ b/src/backend/shared/llm/litellm_gateway.py
@@ -40,6 +40,7 @@ class LiteLLMCompletionGateway:
         model: str,
         base_url: str,
         api_key: str,
+        reasoning_effort: str | None = None,
         completion_fn: CompletionFn | None = None,
         acompletion_fn: AsyncCompletionFn | None = None,
     ) -> None:
@@ -51,6 +52,7 @@ class LiteLLMCompletionGateway:
         self._model = _normalize_litellm_model(self._provider, model)
         self._base_url = resolve_openai_compatible_api_base_url(base_url)
         self._api_key = normalized_api_key
+        self._reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
         self._structured_mode_cache_key = _build_structured_mode_cache_key(
             provider=self._provider,
             base_url=self._base_url,
@@ -78,8 +80,14 @@ class LiteLLMCompletionGateway:
             response_format=response_format,
             max_tokens=max_tokens,
             timeout=timeout,
+            reasoning_effort=self._reasoning_effort,
         )
-        response = self._completion(**request)
+        try:
+            response = self._completion(**request)
+        except Exception as error:
+            if _is_unsupported_reasoning_effort_error(error):
+                raise RuntimeError("此模型不支持思考强度。") from error
+            raise
         content = _extract_completion_content(response)
         if content.strip():
             return content.strip()
@@ -107,8 +115,14 @@ class LiteLLMCompletionGateway:
             response_format=response_format,
             max_tokens=max_tokens,
             timeout=timeout,
+            reasoning_effort=self._reasoning_effort,
         )
-        response = await self._acompletion(**request)
+        try:
+            response = await self._acompletion(**request)
+        except Exception as error:
+            if _is_unsupported_reasoning_effort_error(error):
+                raise RuntimeError("此模型不支持思考强度。") from error
+            raise
         content = _extract_completion_content(response)
         if content.strip():
             return content.strip()
@@ -132,15 +146,23 @@ class LiteLLMCompletionGateway:
         temperature: float = 0,
         response_format: dict[str, Any] | type[BaseModel] | None = None,
     ) -> Iterator[str]:
-        stream = self._completion(
-            model=self._model,
-            messages=_dump_messages(messages),
-            api_base=self._base_url,
-            api_key=self._api_key,
-            temperature=temperature,
-            stream=True,
-            response_format=response_format,
-        )
+        try:
+            stream = self._completion(
+                **_build_stream_request(
+                    model=self._model,
+                    messages=_dump_messages(messages),
+                    api_base=self._base_url,
+                    api_key=self._api_key,
+                    temperature=temperature,
+                    response_format=response_format,
+                    reasoning_effort=self._reasoning_effort,
+                ),
+                stream=True,
+            )
+        except Exception as error:
+            if _is_unsupported_reasoning_effort_error(error):
+                raise RuntimeError("此模型不支持思考强度。") from error
+            raise
         for chunk in stream:
             delta = _extract_stream_delta(chunk)
             if delta:
@@ -153,16 +175,24 @@ class LiteLLMCompletionGateway:
         temperature: float = 0,
         response_format: dict[str, Any] | type[BaseModel] | None = None,
     ) -> Iterator[ChatCompletionStreamChunk]:
-        stream = self._completion(
-            model=self._model,
-            messages=_dump_messages(messages),
-            api_base=self._base_url,
-            api_key=self._api_key,
-            temperature=temperature,
-            stream=True,
-            stream_options={"include_usage": True},
-            response_format=response_format,
-        )
+        try:
+            stream = self._completion(
+                **_build_stream_request(
+                    model=self._model,
+                    messages=_dump_messages(messages),
+                    api_base=self._base_url,
+                    api_key=self._api_key,
+                    temperature=temperature,
+                    response_format=response_format,
+                    reasoning_effort=self._reasoning_effort,
+                ),
+                stream=True,
+                stream_options={"include_usage": True},
+            )
+        except Exception as error:
+            if _is_unsupported_reasoning_effort_error(error):
+                raise RuntimeError("此模型不支持思考强度。") from error
+            raise
         final_usage: dict[str, int] = {}
         for chunk in stream:
             delta = _extract_stream_delta(chunk)
@@ -189,15 +219,23 @@ class LiteLLMCompletionGateway:
         temperature: float = 0,
         response_format: dict[str, Any] | type[BaseModel] | None = None,
     ):
-        stream = await self._acompletion(
-            model=self._model,
-            messages=_dump_messages(messages),
-            api_base=self._base_url,
-            api_key=self._api_key,
-            temperature=temperature,
-            stream=True,
-            response_format=response_format,
-        )
+        try:
+            stream = await self._acompletion(
+                **_build_stream_request(
+                    model=self._model,
+                    messages=_dump_messages(messages),
+                    api_base=self._base_url,
+                    api_key=self._api_key,
+                    temperature=temperature,
+                    response_format=response_format,
+                    reasoning_effort=self._reasoning_effort,
+                ),
+                stream=True,
+            )
+        except Exception as error:
+            if _is_unsupported_reasoning_effort_error(error):
+                raise RuntimeError("此模型不支持思考强度。") from error
+            raise
         async for chunk in stream:
             delta = _extract_stream_delta(chunk)
             if delta:
@@ -330,11 +368,12 @@ def _normalize_litellm_model(provider: str, model: str) -> str:
     normalized_model = model.strip()
     if not normalized_model:
         raise RuntimeError("缺少模型名称，无法调用模型。")
-    if provider != "openai_compatible":
-        raise RuntimeError(f"unsupported llm provider '{provider}'")
     if "/" in normalized_model:
         return normalized_model
-    return f"openai/{normalized_model}"
+    normalized_provider = provider.strip().lower()
+    if not normalized_provider:
+        raise RuntimeError("缺少模型类型，无法调用模型。")
+    return f"{normalized_provider}/{normalized_model}"
 
 
 def _dump_messages(messages: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -351,20 +390,73 @@ def _build_completion_request(
     response_format: dict[str, Any] | type[BaseModel] | None,
     max_tokens: int | None,
     timeout: float | None,
+    reasoning_effort: str | None,
 ) -> dict[str, Any]:
     request: dict[str, Any] = {
         "model": model,
         "messages": messages,
-        "api_base": api_base,
         "api_key": api_key,
         "temperature": temperature,
         "response_format": response_format,
     }
+    if api_base:
+        request["api_base"] = api_base
     if max_tokens is not None:
         request["max_tokens"] = max_tokens
     if timeout is not None:
         request["timeout"] = timeout
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+        request["allowed_openai_params"] = ["reasoning_effort"]
     return request
+
+
+def _build_stream_request(
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    api_base: str,
+    api_key: str,
+    temperature: float,
+    response_format: dict[str, Any] | type[BaseModel] | None,
+    reasoning_effort: str | None,
+) -> dict[str, Any]:
+    request: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "api_key": api_key,
+        "temperature": temperature,
+        "response_format": response_format,
+    }
+    if api_base:
+        request["api_base"] = api_base
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+        request["allowed_openai_params"] = ["reasoning_effort"]
+    return request
+
+
+def _normalize_reasoning_effort(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized == "none":
+        return None
+    if normalized not in {"low", "medium", "high"}:
+        raise RuntimeError(f"unsupported reasoning_effort '{value}'")
+    return normalized
+
+
+def _is_unsupported_reasoning_effort_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return "reasoning_effort" in message and (
+        "unsupported" in message
+        or "does not support" in message
+        or "not support" in message
+        or "unsupportedparams" in message
+    )
 
 
 def _build_structured_request_modes(

--- a/src/backend/video_summary/infrastructure/litellm_web_search.py
+++ b/src/backend/video_summary/infrastructure/litellm_web_search.py
@@ -20,13 +20,14 @@ class LiteLLMNativeWebSearchGateway:
         normalized_api_key = api_key.strip()
         if not normalized_api_key:
             raise RuntimeError("缺少 API Key，无法调用联网搜索。")
-        if provider.strip() != "openai_compatible":
-            raise RuntimeError(f"unsupported web search provider '{provider}'")
         normalized_model = model.strip()
         if not normalized_model:
             raise RuntimeError("缺少模型名称，无法调用联网搜索。")
 
-        self._model = normalized_model if "/" in normalized_model else f"openai/{normalized_model}"
+        normalized_provider = provider.strip().lower()
+        if not normalized_provider:
+            raise RuntimeError("缺少模型类型，无法调用联网搜索。")
+        self._model = normalized_model if "/" in normalized_model else f"{normalized_provider}/{normalized_model}"
         self._base_url = resolve_openai_compatible_api_base_url(base_url)
         self._api_key = normalized_api_key
         self._search_context_size = search_context_size.strip() or "medium"

--- a/src/backend/video_summary/infrastructure/runtime.py
+++ b/src/backend/video_summary/infrastructure/runtime.py
@@ -37,6 +37,7 @@ def build_litellm_completion_gateway(settings: AppSettings) -> LiteLLMCompletion
         model=settings.openai.model,
         base_url=settings.openai.base_url,
         api_key=settings.openai.api_key,
+        reasoning_effort=settings.agent_context.reasoning_effort,
     )
 
 

--- a/src/backend/video_summary/infrastructure/settings.py
+++ b/src/backend/video_summary/infrastructure/settings.py
@@ -18,8 +18,88 @@ VALID_WEB_SEARCH_PROVIDERS = {"litellm"}
 VALID_WEB_SEARCH_MODES = {"native"}
 VALID_WEB_SEARCH_CONTEXT_SIZES = {"low", "medium", "high"}
 VALID_ANSWER_DETAIL_LEVELS = {"short", "medium", "long"}
+VALID_REASONING_EFFORTS = {"none", "low", "medium", "high"}
+VALID_LLM_PROVIDERS = {
+    "ai21",
+    "ai21_chat",
+    "aiohttp_openai",
+    "anthropic",
+    "anthropic_text",
+    "assemblyai",
+    "azure",
+    "azure_ai",
+    "azure_text",
+    "baseten",
+    "bedrock",
+    "cerebras",
+    "clarifai",
+    "cloudflare",
+    "codestral",
+    "cohere",
+    "cohere_chat",
+    "custom",
+    "custom_openai",
+    "dashscope",
+    "databricks",
+    "datarobot",
+    "deepgram",
+    "deepinfra",
+    "deepseek",
+    "elevenlabs",
+    "empower",
+    "featherless_ai",
+    "fireworks_ai",
+    "friendliai",
+    "galadriel",
+    "gemini",
+    "github",
+    "github_copilot",
+    "groq",
+    "hosted_vllm",
+    "humanloop",
+    "huggingface",
+    "infinity",
+    "jina_ai",
+    "langfuse",
+    "litellm_proxy",
+    "lm_studio",
+    "maritalk",
+    "meta_llama",
+    "mistral",
+    "nebius",
+    "nlp_cloud",
+    "novita",
+    "nvidia_nim",
+    "nscale",
+    "ollama",
+    "oobabooga",
+    "openai",
+    "openrouter",
+    "perplexity",
+    "petals",
+    "predibase",
+    "replicate",
+    "sagemaker",
+    "sagemaker_chat",
+    "sambanova",
+    "snowflake",
+    "text-completion-codestral",
+    "text-completion-openai",
+    "together_ai",
+    "topaz",
+    "triton",
+    "vertex_ai",
+    "vertex_ai_beta",
+    "volcengine",
+    "voyage",
+    "watsonx",
+    "watsonx_text",
+    "xai",
+    "xinference",
+}
 DEFAULT_AGENT_CONTEXT_WINDOW_TOKENS = 1_000_000
 DEFAULT_AGENT_ANSWER_DETAIL_LEVEL = "medium"
+DEFAULT_AGENT_REASONING_EFFORT = "none"
 DEFAULT_AGENT_RESERVED_OUTPUT_TOKENS = 20_000
 DEFAULT_AGENT_WARNING_THRESHOLD_RATIO = 0.60
 DEFAULT_AGENT_COMPACT_THRESHOLD_RATIO = 0.80
@@ -83,6 +163,7 @@ class DebugSettings:
 class AgentContextSettings:
     window_tokens: int
     answer_detail_level: str
+    reasoning_effort: str
     reserved_output_tokens: int
     warning_threshold_ratio: float
     compact_threshold_ratio: float
@@ -190,6 +271,12 @@ def load_settings(config_path: Path, root_dir: Path) -> AppSettings:
             default=DEFAULT_AGENT_ANSWER_DETAIL_LEVEL,
             allowed=VALID_ANSWER_DETAIL_LEVELS,
             field_name="agent_context.answer_detail_level",
+        ),
+        reasoning_effort=_normalize_choice(
+            agent_context_payload.get("reasoning_effort"),
+            default=DEFAULT_AGENT_REASONING_EFFORT,
+            allowed=VALID_REASONING_EFFORTS,
+            field_name="agent_context.reasoning_effort",
         ),
         reserved_output_tokens=_normalize_positive_int(
             agent_context_advanced_payload.get("reserved_output_tokens"),
@@ -414,6 +501,22 @@ def replace_agent_context_answer_detail_level(settings: AppSettings, answer_deta
     )
 
 
+def replace_agent_context_reasoning_effort(settings: AppSettings, reasoning_effort: str) -> AppSettings:
+    normalized_reasoning_effort = _normalize_choice(
+        reasoning_effort,
+        default=DEFAULT_AGENT_REASONING_EFFORT,
+        allowed=VALID_REASONING_EFFORTS,
+        field_name="agent_context.reasoning_effort",
+    )
+    return replace(
+        settings,
+        agent_context=replace(
+            settings.agent_context,
+            reasoning_effort=normalized_reasoning_effort,
+        ),
+    )
+
+
 def replace_video_generation_concurrency(settings: AppSettings, video_generation_concurrency: int) -> AppSettings:
     normalized_concurrency = _normalize_positive_int(
         video_generation_concurrency,
@@ -503,6 +606,7 @@ def _render_settings_toml(settings: AppSettings) -> str:
         "[agent_context]",
         f"window_tokens = {settings.agent_context.window_tokens}",
         f'answer_detail_level = "{settings.agent_context.answer_detail_level}"',
+        f'reasoning_effort = "{settings.agent_context.reasoning_effort}"',
         "",
         "[agent_context.advanced]",
         f"reserved_output_tokens = {settings.agent_context.reserved_output_tokens}",
@@ -632,7 +736,7 @@ class EnvSettings:
 def load_env_settings(root_dir: Path) -> EnvSettings:
     values = _load_dotenv(root_dir / ".env")
     return EnvSettings(
-        provider=values.get("OPENAI_PROVIDER", "openai_compatible").strip() or "openai_compatible",
+        provider=_normalize_env_provider(values.get("OPENAI_PROVIDER")),
         base_url=normalize_openai_base_url(values.get("OPENAI_BASE_URL", "").strip()),
         model=values.get("OPENAI_MODEL", "").strip(),
         api_key=values.get("OPENAI_API_KEY", "").strip(),
@@ -689,3 +793,14 @@ def _load_dotenv(dotenv_path: Path) -> dict[str, str]:
         if normalized_key:
             values[normalized_key] = normalized_value
     return values
+
+
+def _normalize_env_provider(value: object) -> str:
+    if not isinstance(value, str):
+        return "openai"
+    normalized = value.strip().lower()
+    if not normalized or normalized == "openai_compatible":
+        return "openai"
+    if normalized == "qwen":
+        return "dashscope"
+    return normalized

--- a/src/backend/video_summary/infrastructure/settings_service.py
+++ b/src/backend/video_summary/infrastructure/settings_service.py
@@ -12,6 +12,8 @@ from backend.video_summary.infrastructure.settings import (
     VALID_THEMES,
     VALID_TRANSCRIPTION_MODES,
     VALID_ANSWER_DETAIL_LEVELS,
+    VALID_LLM_PROVIDERS,
+    VALID_REASONING_EFFORTS,
     WorkspaceUiSettings,
     load_env_settings,
     load_settings,
@@ -19,6 +21,7 @@ from backend.video_summary.infrastructure.settings import (
     replace_agent_retrieval_runtime_settings,
     replace_agent_context_window_tokens,
     replace_agent_context_answer_detail_level,
+    replace_agent_context_reasoning_effort,
     replace_faster_whisper_model_size,
     replace_faster_whisper_transcription_mode,
     replace_transcript_enhancement_enabled,
@@ -57,6 +60,7 @@ class WorkspaceSettings:
     rag_rerank_enabled: bool
     window_tokens: int
     answer_detail_level: str
+    reasoning_effort: str
     video_generation_concurrency: int
     web_search_enabled: bool
 
@@ -78,6 +82,7 @@ class SettingsServicePort(Protocol):
         rag_rerank_enabled: bool,
         window_tokens: int,
         answer_detail_level: str,
+        reasoning_effort: str,
         video_generation_concurrency: int,
         web_search_enabled: bool,
     ) -> WorkspaceSettings:
@@ -143,6 +148,7 @@ class SettingsService:
             rag_rerank_enabled=rag_rerank_enabled,
             window_tokens=settings.agent_context.window_tokens,
             answer_detail_level=settings.agent_context.answer_detail_level,
+            reasoning_effort=settings.agent_context.reasoning_effort,
             video_generation_concurrency=settings.generation.video_generation_concurrency,
             web_search_enabled=settings.web_search.enabled,
         )
@@ -160,6 +166,7 @@ class SettingsService:
         rag_rerank_enabled: bool,
         window_tokens: int,
         answer_detail_level: str,
+        reasoning_effort: str,
         video_generation_concurrency: int,
         web_search_enabled: bool,
     ) -> WorkspaceSettings:
@@ -173,6 +180,8 @@ class SettingsService:
             raise SettingsValidationError("window_tokens 必须是正整数。")
         if answer_detail_level not in VALID_ANSWER_DETAIL_LEVELS:
             raise SettingsValidationError("answer_detail_level 必须是 short、medium 或 long。")
+        if reasoning_effort not in VALID_REASONING_EFFORTS:
+            raise SettingsValidationError("reasoning_effort 必须是 none、low、medium 或 high。")
         if rag_max_hits <= 0:
             raise SettingsValidationError("rag_max_hits 必须是正整数。")
         if video_generation_concurrency <= 0:
@@ -204,6 +213,7 @@ class SettingsService:
             )
             next_settings = replace_agent_context_window_tokens(next_settings, window_tokens)
             next_settings = replace_agent_context_answer_detail_level(next_settings, answer_detail_level)
+            next_settings = replace_agent_context_reasoning_effort(next_settings, reasoning_effort)
             next_settings = replace_video_generation_concurrency(next_settings, video_generation_concurrency)
             next_settings = replace_web_search_enabled(next_settings, web_search_enabled)
             save_settings(self._config_path, next_settings)
@@ -219,6 +229,7 @@ class SettingsService:
             rag_rerank_enabled=next_settings.agent_retrieval.rerank_enabled,
             window_tokens=next_settings.agent_context.window_tokens,
             answer_detail_level=next_settings.agent_context.answer_detail_level,
+            reasoning_effort=next_settings.agent_context.reasoning_effort,
             video_generation_concurrency=next_settings.generation.video_generation_concurrency,
             web_search_enabled=next_settings.web_search.enabled,
         )
@@ -284,6 +295,7 @@ class SettingsService:
             base_url=provider_settings.openai_base_url,
             model=provider_settings.openai_model,
             api_key=self._resolve_openai_api_key(openai_api_key),
+            reasoning_effort=load_settings(self._config_path, self._root_dir).agent_context.reasoning_effort,
         )
         try:
             response = gateway.test_connection()
@@ -326,13 +338,15 @@ class SettingsService:
         normalized_base_url = openai_base_url.strip()
         normalized_model = openai_model.strip()
 
-        if normalized_provider != "openai_compatible":
-            raise SettingsValidationError(f"unsupported llm provider '{normalized_provider}'")
-        if not normalized_base_url:
-            raise SettingsValidationError("模型接口地址不能为空，例如 https://api.deepseek.com/v1")
-        if not normalized_base_url.startswith(("http://", "https://")):
+        if normalized_provider == "qwen":
+            normalized_provider = "dashscope"
+        if normalized_provider not in VALID_LLM_PROVIDERS:
             raise SettingsValidationError(
-                "模型接口地址必须包含 http:// 或 https://，例如 https://api.deepseek.com/v1"
+                f"unsupported llm provider '{normalized_provider}'"
+            )
+        if normalized_base_url and not normalized_base_url.startswith(("http://", "https://")):
+            raise SettingsValidationError(
+                "模型接口地址必须包含 http:// 或 https://。"
             )
         if not normalized_model:
             raise SettingsValidationError("模型名称不能为空。")

--- a/src/frontend/src/features/workspace/model/providerRequestUrl.js
+++ b/src/frontend/src/features/workspace/model/providerRequestUrl.js
@@ -27,6 +27,9 @@ function resolveOpenAICompatibleApiBaseUrl(value) {
 }
 
 function normalizeProviderBaseUrl(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
   let normalized = value.trim().replace(/\/+$/, "");
   for (const endpoint of ["/chat/completions", "/responses", "/completions"]) {
     if (normalized.endsWith(endpoint)) {

--- a/src/frontend/src/features/workspace/model/workspaceApi.js
+++ b/src/frontend/src/features/workspace/model/workspaceApi.js
@@ -36,6 +36,7 @@ export async function loadWorkspaceSettings() {
     webSearchEnabled: payload.web_search_enabled,
     windowTokens: payload.window_tokens,
     answerDetailLevel: payload.answer_detail_level,
+    reasoningEffort: payload.reasoning_effort,
     videoGenerationConcurrency: payload.video_generation_concurrency,
   };
 }
@@ -76,6 +77,7 @@ export async function updateWorkspaceSettings(settings) {
       web_search_enabled: settings.webSearchEnabled,
       window_tokens: settings.windowTokens,
       answer_detail_level: settings.answerDetailLevel,
+      reasoning_effort: settings.reasoningEffort,
       video_generation_concurrency: settings.videoGenerationConcurrency,
     }),
   });
@@ -91,6 +93,7 @@ export async function updateWorkspaceSettings(settings) {
     webSearchEnabled: payload.web_search_enabled,
     windowTokens: payload.window_tokens,
     answerDetailLevel: payload.answer_detail_level,
+    reasoningEffort: payload.reasoning_effort,
     videoGenerationConcurrency: payload.video_generation_concurrency,
   };
 }

--- a/src/frontend/src/features/workspace/model/workspaceSettingsActions.js
+++ b/src/frontend/src/features/workspace/model/workspaceSettingsActions.js
@@ -29,7 +29,7 @@ export function createWorkspaceSettingsActions({ state, dispatch }) {
   async function onChangeSetting(key, value) {
     if (key === "openaiBaseUrl") {
       dispatch({ type: "workspace_setting_edited", key, value });
-      if (!isSaveableOpenaiBaseUrl(value)) {
+      if (String(value).trim() && !isSaveableOpenaiBaseUrl(value)) {
         return;
       }
       try {

--- a/src/frontend/src/features/workspace/model/workspaceState.js
+++ b/src/frontend/src/features/workspace/model/workspaceState.js
@@ -8,8 +8,8 @@ export const defaultUiSettings = {
   ragMaxHits: 5,
   ragRerankEnabled: true,
   webSearchEnabled: false,
-  llmProvider: "openai_compatible",
-  openaiBaseUrl: "http://127.0.0.1:8317/v1",
+  llmProvider: "openai",
+  openaiBaseUrl: "",
   openaiModel: "gpt-5.4",
   hfEndpoint: "https://hf-mirror.com",
   openaiApiKey: "",
@@ -17,8 +17,88 @@ export const defaultUiSettings = {
   openaiApiKeyMasked: "",
   windowTokens: 1000000,
   answerDetailLevel: "medium",
+  reasoningEffort: "none",
   videoGenerationConcurrency: 1,
 };
+
+const validLlmProviders = new Set([
+  "ai21",
+  "ai21_chat",
+  "aiohttp_openai",
+  "anthropic",
+  "anthropic_text",
+  "assemblyai",
+  "azure",
+  "azure_ai",
+  "azure_text",
+  "baseten",
+  "bedrock",
+  "cerebras",
+  "clarifai",
+  "cloudflare",
+  "codestral",
+  "cohere",
+  "cohere_chat",
+  "custom",
+  "custom_openai",
+  "dashscope",
+  "databricks",
+  "datarobot",
+  "deepgram",
+  "deepinfra",
+  "deepseek",
+  "elevenlabs",
+  "empower",
+  "featherless_ai",
+  "fireworks_ai",
+  "friendliai",
+  "galadriel",
+  "gemini",
+  "github",
+  "github_copilot",
+  "groq",
+  "hosted_vllm",
+  "humanloop",
+  "huggingface",
+  "infinity",
+  "jina_ai",
+  "langfuse",
+  "litellm_proxy",
+  "lm_studio",
+  "maritalk",
+  "meta_llama",
+  "mistral",
+  "nebius",
+  "nlp_cloud",
+  "novita",
+  "nvidia_nim",
+  "nscale",
+  "ollama",
+  "oobabooga",
+  "openai",
+  "openrouter",
+  "perplexity",
+  "petals",
+  "predibase",
+  "replicate",
+  "sagemaker",
+  "sagemaker_chat",
+  "sambanova",
+  "snowflake",
+  "text-completion-codestral",
+  "text-completion-openai",
+  "together_ai",
+  "topaz",
+  "triton",
+  "vertex_ai",
+  "vertex_ai_beta",
+  "volcengine",
+  "voyage",
+  "watsonx",
+  "watsonx_text",
+  "xai",
+  "xinference",
+]);
 
 export function createWelcomeChatMessages() {
   return [
@@ -626,11 +706,11 @@ export function normalizeUiSettings(value) {
       typeof record.ragRerankEnabled === "boolean" ? record.ragRerankEnabled : true,
     webSearchEnabled:
       typeof record.webSearchEnabled === "boolean" ? record.webSearchEnabled : false,
-    llmProvider: record.llmProvider === "openai_compatible" ? record.llmProvider : "openai_compatible",
+    llmProvider: validLlmProviders.has(record.llmProvider) ? record.llmProvider : "openai",
     openaiBaseUrl:
       typeof record.openaiBaseUrl === "string" && record.openaiBaseUrl.trim()
         ? record.openaiBaseUrl.trim()
-        : "http://127.0.0.1:8317/v1",
+        : "",
     openaiModel:
       typeof record.openaiModel === "string" && record.openaiModel.trim()
         ? record.openaiModel.trim()
@@ -650,6 +730,10 @@ export function normalizeUiSettings(value) {
       record.answerDetailLevel === "short" || record.answerDetailLevel === "long"
         ? record.answerDetailLevel
         : "medium",
+    reasoningEffort:
+      record.reasoningEffort === "low" || record.reasoningEffort === "medium" || record.reasoningEffort === "high"
+        ? record.reasoningEffort
+        : "none",
     videoGenerationConcurrency:
       typeof record.videoGenerationConcurrency === "number"
         && Number.isInteger(record.videoGenerationConcurrency)

--- a/src/frontend/src/features/workspace/ui/WorkspaceSettingsPanel.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceSettingsPanel.jsx
@@ -3,7 +3,9 @@ import { motion, AnimatePresence } from "framer-motion";
 import { popScaleVariant, blurVariant } from "../../../lib/animations";
 import { Settings2, Cpu, Globe, Key, FileText, X, LoaderCircle, Download } from "lucide-react";
 import {
+  WorkspaceProviderSelect,
   WorkspaceSegmentedControl,
+  WorkspaceSelect,
   WorkspaceSettingRow,
   WorkspaceTextInput,
   WorkspaceToggleSwitch,
@@ -50,6 +52,25 @@ export function WorkspaceSettingsPanel({
   const rerankerNeedsDownload = rerankerModel != null && !rerankerModel.downloaded;
   const effectiveRerankEnabled = !rerankerNeedsDownload && ui.ragRerankEnabled;
   const providerTargetUrl = buildOpenAICompatibleChatCompletionsUrl(ui.openaiBaseUrl);
+  const providerOptions = [
+    { id: "openai", label: "openai", group: "官方", description: "OpenAI 官方 API；大多数中转站也兼容" },
+    { id: "anthropic", label: "anthropic", group: "官方", description: "Anthropic Claude 官方 API" },
+    { id: "gemini", label: "gemini", group: "官方", description: "Google Gemini 官方 API" },
+    { id: "deepseek", label: "deepseek", group: "官方", description: "DeepSeek 官方 API" },
+    { id: "xai", label: "xai", group: "官方", description: "xAI Grok 官方 API" },
+    { id: "mistral", label: "mistral", group: "官方", description: "Mistral AI 官方 API" },
+    { id: "dashscope", label: "dashscope (Qwen)", group: "官方", description: "阿里云通义千问官方通道" },
+    { id: "volcengine", label: "volcengine (字节)", group: "官方", description: "火山引擎豆包官方通道" },
+    { id: "minimax", label: "minimax (MiniMax)", group: "官方", description: "MiniMax 官方 API" },
+    { id: "azure", label: "azure", group: "平台", description: "Azure OpenAI，微软云托管通道" },
+    { id: "vertex_ai", label: "vertex_ai", group: "平台", description: "Google Cloud Vertex AI，谷歌云托管通道" },
+    { id: "bedrock", label: "bedrock", group: "平台", description: "AWS Bedrock，亚马逊云托管模型平台" },
+    { id: "groq", label: "groq", group: "平台", description: "Groq 高速推理平台" },
+    { id: "perplexity", label: "perplexity", group: "平台", description: "Perplexity AI 搜索增强平台，支持联网搜索" },
+    { id: "openrouter", label: "openrouter", group: "平台", description: "OpenRouter 模型路由平台，支持数百个模型" },
+    { id: "ollama", label: "ollama", group: "本地", description: "本地运行，Ollama 默认接口" },
+    { id: "lm_studio", label: "lm_studio", group: "本地", description: "本地运行，LM Studio 内置服务器" },
+  ];
 
   const tabs = [
     { id: "general", label: "常规与显示", icon: Settings2 },
@@ -433,25 +454,26 @@ export function WorkspaceSettingsPanel({
                 </div>
 
                 <WorkspaceSettingRow
-                  title="供应商协议"
-                  description="目前仅支持openai协议"
+                  title="模型协议"
+                  description="选择 LiteLLM 调用协议；自定义中转通常选 openai。"
                 >
-                  <WorkspaceSegmentedControl
-                    value="openai_compatible"
-                    options={[{ id: "openai_compatible", label: "OpenAI 兼容" }]}
-                    onChange={() => { }}
+                  <WorkspaceProviderSelect
+                    value={ui.llmProvider}
+                    options={providerOptions}
+                    onChange={(nextValue) => onChangeSetting("llmProvider", nextValue)}
+                    className="w-full sm:w-[280px]"
                   />
                 </WorkspaceSettingRow>
 
                 <WorkspaceSettingRow
                   title="API 根地址"
-                  description="填写 OpenAI 兼容 API 根地址，例如 `https://api.deepseek.com` 或 `https://api.deepseek.com/v1`。"
+                  description="模型的URL"
                 >
                   <div className="w-full sm:w-[340px]">
                     <WorkspaceTextInput
                       value={ui.openaiBaseUrl}
                       onChange={(nextValue) => onChangeSetting("openaiBaseUrl", nextValue)}
-                      placeholder="https://api.openai.com/v1"
+                      placeholder="留空使用 provider 默认地址"
                       className="w-full"
                     />
                     {providerTargetUrl ? (
@@ -465,13 +487,29 @@ export function WorkspaceSettingsPanel({
 
                 <WorkspaceSettingRow
                   title="模型名称"
-                  description="例如 `gpt-5.4` 或你的 OpenAI 兼容服务实际支持的模型名。"
+                  description="填写模型名称，例如 `gpt-5.4`、`deepseek-v4-pro`、`qwen3-max`"
                 >
                   <WorkspaceTextInput
                     value={ui.openaiModel}
                     onChange={(nextValue) => onChangeSetting("openaiModel", nextValue)}
                     placeholder="gpt-5.4"
                     className="w-full sm:w-[240px]"
+                  />
+                </WorkspaceSettingRow>
+
+                <WorkspaceSettingRow
+                  title="思考强度"
+                  description="控制模型的思考深度"
+                >
+                  <WorkspaceSegmentedControl
+                    value={ui.reasoningEffort}
+                    options={[
+                      { id: "none", label: "无" },
+                      { id: "low", label: "低" },
+                      { id: "medium", label: "中" },
+                      { id: "high", label: "高" },
+                    ]}
+                    onChange={(nextValue) => onChangeSetting("reasoningEffort", nextValue)}
                   />
                 </WorkspaceSettingRow>
 

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceSettingsControls.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceSettingsControls.jsx
@@ -1,3 +1,78 @@
+import { useState, useRef, useEffect } from "react";
+import { ChevronDown, Check } from "lucide-react";
+
+export function WorkspaceProviderSelect({ value, onChange, options, className = "" }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+  const selected = options.find((o) => o.id === value);
+
+  // Build ordered group list, preserving first-seen order
+  const groups = [];
+  const groupMap = {};
+  for (const opt of options) {
+    const g = opt.group ?? "其他";
+    if (!groupMap[g]) { groupMap[g] = []; groups.push(g); }
+    groupMap[g].push(opt);
+  }
+
+  useEffect(() => {
+    function onOutside(e) {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onOutside);
+    return () => document.removeEventListener("mousedown", onOutside);
+  }, []);
+
+  return (
+    <div ref={ref} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between gap-2 rounded-xl border border-stone-200 bg-white px-4 py-2.5 text-left text-sm text-stone-900 outline-none transition-colors hover:border-accent/50 focus:border-accent dark:border-stone-700 dark:bg-stone-900 dark:text-stone-100"
+      >
+        <span className="truncate font-medium">{selected?.label ?? value}</span>
+        <ChevronDown size={15} className={`shrink-0 text-stone-400 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 right-0 top-full z-50 mt-1.5 max-h-80 overflow-y-auto rounded-xl border border-stone-200 bg-white shadow-xl dark:border-stone-700 dark:bg-stone-900">
+          {groups.map((group, gi) => (
+            <div key={group}>
+              {gi > 0 && <div className="mx-3 border-t border-stone-100 dark:border-stone-800" />}
+              <div className="px-4 pb-1 pt-3 text-[10px] font-bold uppercase tracking-widest text-stone-400 dark:text-stone-500">
+                {group}
+              </div>
+              {groupMap[group].map((option) => {
+                const active = option.id === value;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => { onChange(option.id); setOpen(false); }}
+                    className={`flex w-full items-start gap-3 px-4 py-2.5 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-800/60 ${active ? "bg-accent/5 dark:bg-accent/10" : ""}`}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className={`text-sm font-semibold ${active ? "text-accent" : "text-stone-900 dark:text-stone-100"}`}>
+                        {option.label}
+                      </div>
+                      {option.description && (
+                        <div className="mt-0.5 text-xs leading-snug text-stone-400 dark:text-stone-500">
+                          {option.description}
+                        </div>
+                      )}
+                    </div>
+                    {active && <Check size={14} className="mt-0.5 shrink-0 text-accent" />}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function WorkspaceSettingRow({ title, description, children, contentClassName = "" }) {
   const contentLayoutClassName = contentClassName || "2xl:w-auto 2xl:shrink-0";
 
@@ -71,5 +146,26 @@ export function WorkspaceTextInput({
       placeholder={placeholder}
       className={`max-w-full rounded-xl border border-stone-200 bg-white px-4 py-2.5 text-sm text-stone-900 outline-none focus:border-accent dark:border-stone-700 dark:bg-stone-900 dark:text-stone-100 ${className}`}
     />
+  );
+}
+
+export function WorkspaceSelect({
+  value,
+  onChange,
+  options,
+  className = "",
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className={`max-w-full rounded-xl border border-stone-200 bg-white px-4 py-2.5 text-sm text-stone-900 outline-none focus:border-accent dark:border-stone-700 dark:bg-stone-900 dark:text-stone-100 ${className}`}
+    >
+      {options.map((option) => (
+        <option key={option.id} value={option.id}>
+          {option.label}
+        </option>
+      ))}
+    </select>
   );
 }

--- a/tests/backend/integration/agent/test_agent_stream_errors.py
+++ b/tests/backend/integration/agent/test_agent_stream_errors.py
@@ -195,7 +195,7 @@ class FakeWebSearchSettings:
 
 
 class FakeEnvSettings:
-    provider = "openai_compatible"
+    provider = "openai"
     model = "test-model"
     base_url = "https://api.example.com/v1"
     api_key = "test-key"
@@ -284,7 +284,7 @@ class DisabledWebSearchSettings:
 
 def _build_bad_base_url_agent_service(scope_type: str) -> AgentGraphService:
     gateway = LiteLLMChatGateway(
-        provider="openai_compatible",
+        provider="openai",
         model="gpt-5.4",
         base_url="http://127.0.0.1:9",
         api_key="sk-test",

--- a/tests/backend/integration/api/test_provider_settings_api.py
+++ b/tests/backend/integration/api/test_provider_settings_api.py
@@ -21,7 +21,7 @@ class ProviderSettingsApiTests(unittest.TestCase):
             response = client.put(
                 "/api/provider-settings",
                 json={
-                    "llm_provider": "openai_compatible",
+                    "llm_provider": "openai",
                     "openai_base_url": "http://127.0.0.1:8317",
                     "openai_model": "gpt-5.4",
                     "openai_api_key": "sk-test",
@@ -45,7 +45,7 @@ class ProviderSettingsApiTests(unittest.TestCase):
             response = client.post(
                 "/api/provider-settings/test",
                 json={
-                    "llm_provider": "openai_compatible",
+                    "llm_provider": "deepseek",
                     "openai_base_url": "http://127.0.0.1:8317",
                     "openai_model": "gpt-5.4",
                     "openai_api_key": "sk-test",

--- a/tests/backend/unit/llm/test_litellm_gateway.py
+++ b/tests/backend/unit/llm/test_litellm_gateway.py
@@ -15,12 +15,12 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
     def setUp(self) -> None:
         clear_structured_mode_cache()
 
-    def test_uses_litellm_pydantic_schema_first_for_openai_compatible_models(self) -> None:
+    def test_uses_litellm_pydantic_schema_first_for_openai_models(self) -> None:
         completion = CapturingCompletion(
             '{"answer": "ok", "citations": ["e1"], "used_source_types": ["transcript"]}'
         )
         gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://example.invalid/v1",
             api_key="test-key",
@@ -41,7 +41,7 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
     def test_adds_v1_suffix_to_root_base_url_for_requests(self) -> None:
         completion = CapturingCompletion("ok")
         gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://jiuuij.de5.net",
             api_key="test-key",
@@ -57,7 +57,7 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
     def test_keeps_existing_v1_suffix_for_requests(self) -> None:
         completion = CapturingCompletion("ok")
         gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://jiuuij.de5.net/v1/",
             api_key="test-key",
@@ -69,13 +69,90 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
 
         self.assertEqual(completion.api_bases, ["https://jiuuij.de5.net/v1"])
 
+    def test_passes_reasoning_effort_to_litellm_requests(self) -> None:
+        completion = CapturingCompletion("ok")
+        gateway = LiteLLMCompletionGateway(
+            provider="openai",
+            model="test-model",
+            base_url="https://example.invalid/v1",
+            api_key="test-key",
+            reasoning_effort="high",
+            completion_fn=completion,
+            acompletion_fn=unused_async_completion,
+        )
+
+        gateway.complete_text([{"role": "user", "content": "ping"}])
+
+        self.assertEqual(completion.reasoning_efforts, ["high"])
+
+    def test_allows_reasoning_effort_for_openai_compatible_custom_models(self) -> None:
+        completion = CapturingCompletion("ok")
+        gateway = LiteLLMCompletionGateway(
+            provider="openai",
+            model="deepseek-v4-pro",
+            base_url="https://example.invalid/v1",
+            api_key="test-key",
+            reasoning_effort="medium",
+            completion_fn=completion,
+            acompletion_fn=unused_async_completion,
+        )
+
+        gateway.complete_text([{"role": "user", "content": "ping"}])
+
+        self.assertEqual(completion.allowed_openai_params, [["reasoning_effort"]])
+
+    def test_omits_reasoning_effort_when_disabled(self) -> None:
+        completion = CapturingCompletion("ok")
+        gateway = LiteLLMCompletionGateway(
+            provider="openai",
+            model="test-model",
+            base_url="https://example.invalid/v1",
+            api_key="test-key",
+            reasoning_effort="none",
+            completion_fn=completion,
+            acompletion_fn=unused_async_completion,
+        )
+
+        gateway.complete_text([{"role": "user", "content": "ping"}])
+
+        self.assertEqual(completion.reasoning_efforts, [None])
+
+    def test_raises_clear_error_when_reasoning_effort_is_not_supported(self) -> None:
+        gateway = LiteLLMCompletionGateway(
+            provider="openai",
+            model="test-model",
+            base_url="https://example.invalid/v1",
+            api_key="test-key",
+            reasoning_effort="high",
+            completion_fn=RejectingReasoningEffortCompletion(),
+            acompletion_fn=unused_async_completion,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "此模型不支持思考强度"):
+            gateway.complete_text([{"role": "user", "content": "ping"}])
+
+    def test_uses_litellm_provider_prefix_for_bare_model_names(self) -> None:
+        completion = CapturingCompletion("ok")
+        gateway = LiteLLMCompletionGateway(
+            provider="deepseek",
+            model="deepseek-v4-pro",
+            base_url="https://example.invalid/v1",
+            api_key="test-key",
+            completion_fn=completion,
+            acompletion_fn=unused_async_completion,
+        )
+
+        gateway.complete_text([{"role": "user", "content": "ping"}])
+
+        self.assertEqual(completion.models, ["deepseek/deepseek-v4-pro"])
+
     def test_falls_back_to_json_object_when_schema_is_rejected(self) -> None:
         completion = RejectingFirstResponseFormatCompletion(
             SeriesAnswerPayload,
             '{"answer": "ok", "citations": ["e1"], "used_source_types": ["transcript"]}',
         )
         gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://example.invalid/v1",
             api_key="test-key",
@@ -99,7 +176,7 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
             '{"answer": "ok", "citations": ["e1"], "used_source_types": ["transcript"]}'
         )
         gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://example.invalid/v1",
             api_key="test-key",
@@ -123,7 +200,7 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
             '{"answer": "ok", "citations": ["e1"], "used_source_types": ["transcript"]}'
         )
         gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://example.invalid/v1",
             api_key="test-key",
@@ -152,7 +229,7 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
             '{"answer": "ok", "citations": ["e1"], "used_source_types": ["transcript"]}',
         )
         gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://example.invalid/v1",
             api_key="test-key",
@@ -180,7 +257,7 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
             '{"answer": "ok", "citations": ["e1"], "used_source_types": ["transcript"]}',
         )
         first_gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://example.invalid/v1",
             api_key="first-key",
@@ -191,7 +268,7 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
             '{"answer": "ok", "citations": ["e1"], "used_source_types": ["transcript"]}'
         )
         second_gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://example.invalid/v1",
             api_key="second-key",
@@ -216,7 +293,7 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
             '{"answer": "ok", "citations": ["e1"], "used_source_types": ["transcript"]}'
         )
         gateway = LiteLLMCompletionGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="test-model",
             base_url="https://example.invalid/v1",
             api_key="test-key",
@@ -244,11 +321,17 @@ class CapturingCompletion:
         self.messages: list[list[dict[str, object]]] = []
         self.response_formats: list[object] = []
         self.api_bases: list[str] = []
+        self.reasoning_efforts: list[object] = []
+        self.allowed_openai_params: list[object] = []
+        self.models: list[str] = []
 
     def __call__(self, **kwargs):
         self.messages.append(list(kwargs["messages"]))
         self.response_formats.append(kwargs.get("response_format"))
         self.api_bases.append(kwargs["api_base"])
+        self.reasoning_efforts.append(kwargs.get("reasoning_effort"))
+        self.allowed_openai_params.append(kwargs.get("allowed_openai_params"))
+        self.models.append(kwargs["model"])
         return {"choices": [{"message": {"content": self._content}}]}
 
 
@@ -290,6 +373,12 @@ class RejectingBaseModelResponseFormatsCompletion(CapturingCompletion):
                 raise RuntimeError("response_format json_schema is not supported")
             self._has_seen_schema_success = True
         return {"choices": [{"message": {"content": self._content}}]}
+
+
+class RejectingReasoningEffortCompletion:
+    def __call__(self, **kwargs):
+        del kwargs
+        raise RuntimeError("openai does not support parameters: ['reasoning_effort']")
 
 
 async def unused_async_completion(**kwargs):

--- a/tests/backend/unit/llm/test_litellm_web_search.py
+++ b/tests/backend/unit/llm/test_litellm_web_search.py
@@ -11,7 +11,7 @@ class LiteLLMNativeWebSearchGatewayTests(unittest.TestCase):
     def test_search_passes_native_web_search_options_and_extracts_url_citations(self) -> None:
         completion = FakeSearchCompletion()
         gateway = LiteLLMNativeWebSearchGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="gpt-5-search-api",
             base_url="https://api.example.com/v1",
             api_key="test-key",
@@ -34,7 +34,7 @@ class LiteLLMNativeWebSearchGatewayTests(unittest.TestCase):
 
     def test_search_fails_when_provider_returns_no_citable_sources(self) -> None:
         gateway = LiteLLMNativeWebSearchGateway(
-            provider="openai_compatible",
+            provider="openai",
             model="gpt-5-search-api",
             base_url="https://api.example.com/v1",
             api_key="test-key",

--- a/tests/backend/unit/settings/test_workspace_settings_service.py
+++ b/tests/backend/unit/settings/test_workspace_settings_service.py
@@ -19,7 +19,7 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
             (root_dir / ".env").write_text(
                 "\n".join(
                     [
-                        "OPENAI_PROVIDER=openai_compatible",
+                        "OPENAI_PROVIDER=openai",
                         "OPENAI_BASE_URL=https://example.com/v1",
                         "OPENAI_MODEL=test-model",
                         "OPENAI_API_KEY=test-key",
@@ -41,6 +41,7 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
             current = service.get_workspace_settings()
             self.assertEqual(current.window_tokens, 1_000_000)
             self.assertEqual(current.answer_detail_level, "medium")
+            self.assertEqual(current.reasoning_effort, "none")
             self.assertEqual(current.video_generation_concurrency, 1)
             self.assertEqual(current.rag_max_hits, 5)
             self.assertTrue(current.rag_rerank_enabled)
@@ -57,12 +58,14 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
                 rag_rerank_enabled=False,
                 window_tokens=222_222,
                 answer_detail_level="long",
+                reasoning_effort="high",
                 video_generation_concurrency=5,
                 web_search_enabled=True,
             )
 
             self.assertEqual(updated.window_tokens, 222_222)
             self.assertEqual(updated.answer_detail_level, "long")
+            self.assertEqual(updated.reasoning_effort, "high")
             self.assertEqual(updated.video_generation_concurrency, 5)
             self.assertEqual(updated.rag_max_hits, 7)
             self.assertFalse(updated.rag_rerank_enabled)
@@ -71,6 +74,7 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
             self.assertIn("[agent_context]", rendered)
             self.assertIn("window_tokens = 222222", rendered)
             self.assertIn('answer_detail_level = "long"', rendered)
+            self.assertIn('reasoning_effort = "high"', rendered)
             self.assertIn("[agent_context.advanced]", rendered)
             self.assertIn("direct_summary_threshold_ratio = 0.9", rendered)
             self.assertIn("[generation]", rendered)
@@ -111,6 +115,7 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
                     rag_rerank_enabled=True,
                     window_tokens=1_000_000,
                     answer_detail_level="medium",
+                    reasoning_effort="medium",
                     video_generation_concurrency=1,
                     web_search_enabled=False,
                 )
@@ -142,6 +147,39 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
                     rag_rerank_enabled=True,
                     window_tokens=1_000_000,
                     answer_detail_level="verbose",
+                    reasoning_effort="medium",
+                    video_generation_concurrency=1,
+                    web_search_enabled=False,
+                )
+
+    def test_update_workspace_settings_rejects_invalid_reasoning_effort(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_dir = Path(temp_dir)
+            (root_dir / "config").mkdir(parents=True, exist_ok=True)
+            (root_dir / ".env").write_text("", encoding="utf-8")
+            config_path = root_dir / "config" / "settings.toml"
+            config_path.write_text(_sample_settings_toml(), encoding="utf-8")
+
+            service = SettingsService(
+                config_path=config_path,
+                root_dir=root_dir,
+                faster_whisper_model_manager=FakeFasterWhisperModelManager(),
+                rag_model_manager=FakeRagModelManager(downloaded={"reranker"}),
+            )
+
+        with self.assertRaisesRegex(SettingsValidationError, "reasoning_effort"):
+            service.update_workspace_settings(
+                    theme="light",
+                    show_takeaways=True,
+                    transcript_enhancement_enabled=True,
+                    asr_model_quality="large-v3-turbo",
+                    transcription_mode="accurate",
+                    rag_embedding_device="cpu",
+                    rag_max_hits=5,
+                    rag_rerank_enabled=True,
+                    window_tokens=1_000_000,
+                    answer_detail_level="medium",
+                    reasoning_effort="minimal",
                     video_generation_concurrency=1,
                     web_search_enabled=False,
                 )
@@ -246,7 +284,7 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
             save_env_settings(
                 root_dir,
                 EnvSettings(
-                    provider="openai_compatible",
+                    provider="openai",
                     base_url="https://jiuuij.de5.net",
                     model="test-model",
                     api_key="test-key",
@@ -274,7 +312,7 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
             with patch("backend.video_summary.infrastructure.settings_service.LiteLLMCompletionGateway", TimeoutGateway):
                 with self.assertRaisesRegex(RuntimeError, "^模型超时$"):
                     service.test_provider_settings(
-                        llm_provider="openai_compatible",
+                        llm_provider="openai",
                         openai_base_url="https://jiuuij.de5.net",
                         openai_model="test-model",
                         openai_api_key=None,

--- a/tests/frontend/features/workspace/model/workspaceState.test.jsx
+++ b/tests/frontend/features/workspace/model/workspaceState.test.jsx
@@ -29,6 +29,25 @@ describe("workspace UI settings", () => {
     expect(normalizeUiSettings({ answerDetailLevel: "long" }).answerDetailLevel).toBe("long");
     expect(normalizeUiSettings({ answerDetailLevel: "verbose" }).answerDetailLevel).toBe("medium");
   });
+
+  it("normalizes the reasoning effort with medium as the safe default", () => {
+    expect(normalizeUiSettings({}).reasoningEffort).toBe("none");
+    expect(normalizeUiSettings({ reasoningEffort: "none" }).reasoningEffort).toBe("none");
+    expect(normalizeUiSettings({ reasoningEffort: "low" }).reasoningEffort).toBe("low");
+    expect(normalizeUiSettings({ reasoningEffort: "medium" }).reasoningEffort).toBe("medium");
+    expect(normalizeUiSettings({ reasoningEffort: "high" }).reasoningEffort).toBe("high");
+    expect(normalizeUiSettings({ reasoningEffort: "minimal" }).reasoningEffort).toBe("none");
+  });
+
+  it("normalizes LiteLLM provider values with openai as the default", () => {
+    expect(normalizeUiSettings({}).llmProvider).toBe("openai");
+    expect(normalizeUiSettings({ llmProvider: "deepseek" }).llmProvider).toBe("deepseek");
+    expect(normalizeUiSettings({ llmProvider: "dashscope" }).llmProvider).toBe("dashscope");
+    expect(normalizeUiSettings({ llmProvider: "openai_compatible" }).llmProvider).toBe("openai");
+    expect(normalizeUiSettings({ llmProvider: "openai_like" }).llmProvider).toBe("openai");
+    expect(normalizeUiSettings({ llmProvider: "ollama_chat" }).llmProvider).toBe("openai");
+    expect(normalizeUiSettings({ llmProvider: "vllm" }).llmProvider).toBe("openai");
+  });
 });
 
 describe("workspaceState chat session persistence", () => {


### PR DESCRIPTION
Fixes #3
## Summary

添加了思考强度的设置

## Changes

- 添加多个支持的模型渠道
- 新增 `reasoning_effort` 设置项，支持 `无 / 低 / 中 / 高`


## Verification

- `python -m pytest tests\backend\unit\llm\test_litellm_gateway.py tests\backend\unit\settings\test_workspace_settings_service.py tests\backend\integration\api\test_provider_settings_api.py -q`
- `npm test -- --run ..\..\tests\frontend\features\workspace\model\workspaceState.test.jsx`