### PR TITLE
Fix : 修复打包后前端资源 MIME 类型错误

### DIFF
--- a/src/backend/api/static_assets.py
+++ b/src/backend/api/static_assets.py
@@ -6,6 +6,12 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+FRONTEND_ASSET_MEDIA_TYPES = {
+    ".css": "text/css",
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+}
+
 
 class NoCacheStaticFiles(StaticFiles):
     def file_response(self, *args, **kwargs) -> FileResponse:
@@ -14,6 +20,12 @@ class NoCacheStaticFiles(StaticFiles):
 
 
 def _with_no_cache(response: FileResponse) -> FileResponse:
+    suffix = Path(response.path).suffix.lower()
+    media_type = FRONTEND_ASSET_MEDIA_TYPES.get(suffix)
+    if media_type is not None:
+        response.media_type = media_type
+        response.headers["Content-Type"] = media_type
+
     response.headers["Cache-Control"] = "no-store"
     return response
 

--- a/tests/backend/integration/packaging/test_release_packaging.py
+++ b/tests/backend/integration/packaging/test_release_packaging.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
@@ -39,6 +40,30 @@ class FrontendStaticMountTests(unittest.TestCase):
             self.assertIn("console.log", asset_response.text)
             self.assertEqual(deep_link_response.status_code, 200)
             self.assertIn("frontend", deep_link_response.text)
+
+    def test_frontend_js_assets_are_served_with_javascript_content_type(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_dir = Path(temp_dir)
+            dist_dir = root_dir / "src" / "frontend" / "dist"
+            assets_dir = dist_dir / "assets"
+            assets_dir.mkdir(parents=True, exist_ok=True)
+            (dist_dir / "index.html").write_text(
+                '<script type="module" src="/assets/app.js"></script>',
+                encoding="utf-8",
+            )
+            (assets_dir / "app.js").write_text("console.log('ok');", encoding="utf-8")
+
+            with patch("starlette.responses.guess_type", return_value=("text/plain", None)):
+                app = create_app(container=DummyContainer(root_dir))
+
+                with TestClient(app) as client:
+                    asset_response = client.get("/assets/app.js")
+
+            self.assertEqual(asset_response.status_code, 200)
+            self.assertIn(
+                asset_response.headers["content-type"].split(";")[0],
+                {"application/javascript", "text/javascript"},
+            )
 
 
 class DummyContainer:


### PR DESCRIPTION
Fixes #12
## Summary
- 为打包后的前端静态资源显式设置已知 MIME 类型
- 阻止 portable Python 环境下 `.js` 模块资源被错误返回为 `text/plain`

## Verification
- `python -m pytest tests/backend/integration/packaging/test_release_packaging.py`