### PR TITLE
fix: support Ollama provider settings

### DIFF
--- a/src/backend/api/bootstrap.py
+++ b/src/backend/api/bootstrap.py
@@ -485,7 +485,7 @@ class LazyAgentRuntimeProvider:
         with self._lock:
             if self._cached_agent_graph_service is None:
                 env_settings = load_env_settings(self._root_dir)
-                if not env_settings.api_key.strip():
+                if env_settings.provider != "ollama" and not env_settings.api_key.strip():
                     raise RuntimeError("缺少 API Key，无法调用 Agent 模型。")
                 app_settings = load_settings(self._root_dir / "config" / "settings.toml", self._root_dir)
                 self._cached_context_budget_service = AgentContextBudgetService(

--- a/src/backend/llm_gateway/base_url.py
+++ b/src/backend/llm_gateway/base_url.py
@@ -25,3 +25,21 @@ def resolve_openai_compatible_api_base_url(value: str) -> str:
         path = f"{path}/v1" if path else "/v1"
 
     return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
+def resolve_provider_api_base_url(provider: str, value: str) -> str:
+    normalized_provider = provider.strip().lower()
+    if normalized_provider == "ollama":
+        return resolve_ollama_api_base_url(value)
+    return resolve_openai_compatible_api_base_url(value)
+
+
+def resolve_ollama_api_base_url(value: str) -> str:
+    normalized = normalize_provider_base_url(value)
+    if normalized.endswith("/api/generate"):
+        return normalized[: -len("/api/generate")].rstrip("/")
+    if normalized.endswith("/api/chat"):
+        return normalized[: -len("/api/chat")].rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized[: -len("/v1")].rstrip("/")
+    return normalized

--- a/src/backend/llm_gateway/litellm_gateway.py
+++ b/src/backend/llm_gateway/litellm_gateway.py
@@ -9,7 +9,7 @@ from typing import Any, TypeVar
 from pydantic import BaseModel
 
 from backend.llm_gateway.chat_stream import ChatCompletionStreamChunk
-from backend.llm_gateway.base_url import resolve_openai_compatible_api_base_url
+from backend.llm_gateway.base_url import resolve_provider_api_base_url
 from backend.llm_gateway.json_mode import describe_validation_error, validate_json_response
 
 
@@ -44,14 +44,13 @@ class LiteLLMCompletionGateway:
         completion_fn: CompletionFn | None = None,
         acompletion_fn: AsyncCompletionFn | None = None,
     ) -> None:
-        normalized_api_key = api_key.strip()
-        if not normalized_api_key:
-            raise RuntimeError("缺少 API Key，无法调用模型。")
-
         self._provider = provider.strip()
+        normalized_api_key = api_key.strip()
+        if not normalized_api_key and not _allows_empty_api_key(self._provider):
+            raise RuntimeError("缺少 API Key，无法调用模型。")
         self._model = _normalize_litellm_model(self._provider, model)
-        self._base_url = resolve_openai_compatible_api_base_url(base_url)
-        self._api_key = normalized_api_key
+        self._base_url = resolve_provider_api_base_url(self._provider, base_url)
+        self._api_key = normalized_api_key or None
         self._reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
         self._structured_mode_cache_key = _build_structured_mode_cache_key(
             provider=self._provider,
@@ -386,6 +385,10 @@ def _normalize_litellm_model(provider: str, model: str) -> str:
     return f"{normalized_provider}/{normalized_model}"
 
 
+def _allows_empty_api_key(provider: str) -> bool:
+    return provider.strip().lower() == "ollama"
+
+
 def _dump_messages(messages: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
     return [dict(message) for message in messages]
 
@@ -579,9 +582,9 @@ def _build_structured_mode_cache_key(
     provider: str,
     base_url: str,
     model: str,
-    api_key: str,
+    api_key: str | None,
 ) -> str:
-    key_hash = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:12]
+    key_hash = hashlib.sha256((api_key or "").encode("utf-8")).hexdigest()[:12]
     return "|".join([provider.strip(), base_url.rstrip("/"), model.strip(), key_hash])
 
 

--- a/src/frontend/src/features/workspace/model/providerRequestUrl.js
+++ b/src/frontend/src/features/workspace/model/providerRequestUrl.js
@@ -3,6 +3,19 @@ export function buildOpenAICompatibleChatCompletionsUrl(baseUrl) {
   return apiBase ? `${apiBase}/chat/completions` : "";
 }
 
+export function buildProviderRequestPreviewUrl(provider, baseUrl) {
+  const normalizedProvider = typeof provider === "string" ? provider.trim().toLowerCase() : "";
+  if (normalizedProvider === "ollama") {
+    return buildOllamaGenerateUrl(baseUrl);
+  }
+  return buildOpenAICompatibleChatCompletionsUrl(baseUrl);
+}
+
+function buildOllamaGenerateUrl(baseUrl) {
+  const apiBase = resolveOllamaApiBaseUrl(baseUrl);
+  return apiBase ? `${apiBase}/api/generate` : "";
+}
+
 function resolveOpenAICompatibleApiBaseUrl(value) {
   const normalized = normalizeProviderBaseUrl(value);
   if (!normalized) {
@@ -24,6 +37,16 @@ function resolveOpenAICompatibleApiBaseUrl(value) {
   parsed.search = "";
   parsed.hash = "";
   return parsed.toString().replace(/\/$/, "");
+}
+
+function resolveOllamaApiBaseUrl(value) {
+  const normalized = normalizeProviderBaseUrl(value) || "http://127.0.0.1:11434";
+  for (const endpoint of ["/api/generate", "/api/chat", "/v1"]) {
+    if (normalized.endsWith(endpoint)) {
+      return normalized.slice(0, -endpoint.length).replace(/\/+$/, "");
+    }
+  }
+  return normalized;
 }
 
 function normalizeProviderBaseUrl(value) {

--- a/src/frontend/src/features/workspace/ui/WorkspaceSettingsPanel.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceSettingsPanel.jsx
@@ -11,7 +11,7 @@ import {
   WorkspaceToggleSwitch,
 } from "./shared/WorkspaceSettingsControls";
 import { MODEL_DOWNLOAD_FAILED_MESSAGE } from "../model/modelDownloadMessages";
-import { buildOpenAICompatibleChatCompletionsUrl } from "../model/providerRequestUrl";
+import { buildProviderRequestPreviewUrl } from "../model/providerRequestUrl";
 
 export function WorkspaceSettingsPanel({
   ui,
@@ -43,6 +43,7 @@ export function WorkspaceSettingsPanel({
   const [showApiKeyValue, setShowApiKeyValue] = useState(false);
   const [apiKeyRevealLoading, setApiKeyRevealLoading] = useState(false);
   const [providerTest, setProviderTest] = useState({ status: "idle", message: "" });
+  const isOllamaProvider = ui.llmProvider === "ollama";
   const hasApiKey = ui.hasOpenaiApiKey;
   const draftApiKey = ui.openaiApiKey.trim();
   const apiKeyDisplayValue = draftApiKey
@@ -53,7 +54,7 @@ export function WorkspaceSettingsPanel({
   const rerankerNeedsDownload = rerankerModel != null && !rerankerModel.downloaded;
   const isRerankerDownloading = rerankerModel?.status === "running" || downloadingRagModelKey === "reranker";
   const effectiveRerankEnabled = !rerankerNeedsDownload && ui.ragRerankEnabled;
-  const providerTargetUrl = buildOpenAICompatibleChatCompletionsUrl(ui.openaiBaseUrl);
+  const providerTargetUrl = buildProviderRequestPreviewUrl(ui.llmProvider, ui.openaiBaseUrl);
   const saveProviderSettingsOnEnter = (event) => {
     if (event.key !== "Enter" || typeof onSaveProviderSettings !== "function") {
       return;
@@ -550,75 +551,77 @@ export function WorkspaceSettingsPanel({
                   />
                 </WorkspaceSettingRow>
 
-                <WorkspaceSettingRow
-                  title="API Key"
-                  description="写入项目根目录 `.env` 的 `OPENAI_API_KEY`。"
-                  contentClassName="2xl:w-full 2xl:flex-1 2xl:shrink"
-                >
-                  <div className="w-full min-w-0 max-w-full rounded-2xl border border-stone-200 bg-white px-4 py-3 dark:border-stone-700 dark:bg-stone-900">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <div className="min-w-0">
-                        <p className={`text-sm font-semibold ${hasApiKey ? "text-success" : "text-stone-500 dark:text-stone-400"}`}>
-                          {hasApiKey ? "已配置" : "未配置"}
-                        </p>
-                        {apiKeyStatus ? (
-                          <p className="mt-1 max-w-full break-all text-xs text-stone-500 [overflow-wrap:anywhere] dark:text-stone-400">
-                            当前状态：{apiKeyDisplayValue}
+                {!isOllamaProvider ? (
+                  <WorkspaceSettingRow
+                    title="API Key"
+                    description="写入项目根目录 `.env` 的 `OPENAI_API_KEY`。"
+                    contentClassName="2xl:w-full 2xl:flex-1 2xl:shrink"
+                  >
+                    <div className="w-full min-w-0 max-w-full rounded-2xl border border-stone-200 bg-white px-4 py-3 dark:border-stone-700 dark:bg-stone-900">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="min-w-0">
+                          <p className={`text-sm font-semibold ${hasApiKey ? "text-success" : "text-stone-500 dark:text-stone-400"}`}>
+                            {hasApiKey ? "已配置" : "未配置"}
                           </p>
-                        ) : null}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={async () => {
-                          if (showApiKeyValue) {
-                            setShowApiKeyValue(false);
-                            return;
-                          }
-                          if (!draftApiKey && typeof onRevealOpenaiApiKey === "function") {
-                            setApiKeyRevealLoading(true);
-                            const revealedKey = await onRevealOpenaiApiKey();
-                            setApiKeyRevealLoading(false);
-                            if (!revealedKey) {
+                          {apiKeyStatus ? (
+                            <p className="mt-1 max-w-full break-all text-xs text-stone-500 [overflow-wrap:anywhere] dark:text-stone-400">
+                              当前状态：{apiKeyDisplayValue}
+                            </p>
+                          ) : null}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={async () => {
+                            if (showApiKeyValue) {
+                              setShowApiKeyValue(false);
                               return;
                             }
-                          }
-                          setShowApiKeyValue(true);
-                        }}
-                        disabled={!apiKeyStatus || apiKeyRevealLoading}
-                        className="w-full rounded-xl border border-stone-200 px-3 py-2 text-xs font-bold text-stone-600 transition-colors hover:bg-stone-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-stone-700 dark:text-stone-300 dark:hover:bg-stone-800 sm:w-auto"
-                      >
-                        {apiKeyRevealLoading ? "读取中..." : showApiKeyValue ? "隐藏" : "显示"}
-                      </button>
+                            if (!draftApiKey && typeof onRevealOpenaiApiKey === "function") {
+                              setApiKeyRevealLoading(true);
+                              const revealedKey = await onRevealOpenaiApiKey();
+                              setApiKeyRevealLoading(false);
+                              if (!revealedKey) {
+                                return;
+                              }
+                            }
+                            setShowApiKeyValue(true);
+                          }}
+                          disabled={!apiKeyStatus || apiKeyRevealLoading}
+                          className="w-full rounded-xl border border-stone-200 px-3 py-2 text-xs font-bold text-stone-600 transition-colors hover:bg-stone-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-stone-700 dark:text-stone-300 dark:hover:bg-stone-800 sm:w-auto"
+                        >
+                          {apiKeyRevealLoading ? "读取中..." : showApiKeyValue ? "隐藏" : "显示"}
+                        </button>
+                      </div>
+                      {showApiKeyValue ? (
+                        <textarea
+                          value={ui.openaiApiKey}
+                          onChange={(event) => onChangeSetting("openaiApiKey", event.target.value)}
+                          placeholder={hasApiKey ? "输入新 Key 以覆盖现有配置" : "sk-..."}
+                          rows={3}
+                          className="mt-3 block w-full min-w-0 max-w-full resize-none overflow-y-auto break-all rounded-xl border border-stone-200 bg-white px-4 py-2.5 font-mono text-sm leading-6 text-stone-900 outline-none [overflow-wrap:anywhere] focus:border-accent dark:border-stone-700 dark:bg-stone-950 dark:text-stone-100"
+                        />
+                      ) : (
+                        <WorkspaceTextInput
+                          type="password"
+                          value={ui.openaiApiKey}
+                          onChange={(nextValue) => onChangeSetting("openaiApiKey", nextValue)}
+                          placeholder={hasApiKey ? "输入新 Key 以覆盖现有配置" : "sk-..."}
+                          className="mt-3 w-full min-w-0 dark:bg-stone-950"
+                        />
+                      )}
+                      <div className="mt-3 flex justify-end">
+                        <button
+                          type="button"
+                          onClick={onSaveApiKey}
+                          disabled={!ui.openaiApiKey.trim()}
+                          className="w-full rounded-xl bg-stone-900 px-4 py-2 text-xs font-bold text-white transition-colors hover:bg-black disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-stone-900 dark:hover:bg-stone-100 sm:w-auto"
+                        >
+                          保存 Key
+                        </button>
+                      </div>
                     </div>
-                    {showApiKeyValue ? (
-                      <textarea
-                        value={ui.openaiApiKey}
-                        onChange={(event) => onChangeSetting("openaiApiKey", event.target.value)}
-                        placeholder={hasApiKey ? "输入新 Key 以覆盖现有配置" : "sk-..."}
-                        rows={3}
-                        className="mt-3 block w-full min-w-0 max-w-full resize-none overflow-y-auto break-all rounded-xl border border-stone-200 bg-white px-4 py-2.5 font-mono text-sm leading-6 text-stone-900 outline-none [overflow-wrap:anywhere] focus:border-accent dark:border-stone-700 dark:bg-stone-950 dark:text-stone-100"
-                      />
-                    ) : (
-                      <WorkspaceTextInput
-                        type="password"
-                        value={ui.openaiApiKey}
-                        onChange={(nextValue) => onChangeSetting("openaiApiKey", nextValue)}
-                        placeholder={hasApiKey ? "输入新 Key 以覆盖现有配置" : "sk-..."}
-                        className="mt-3 w-full min-w-0 dark:bg-stone-950"
-                      />
-                    )}
-                    <div className="mt-3 flex justify-end">
-                      <button
-                        type="button"
-                        onClick={onSaveApiKey}
-                        disabled={!ui.openaiApiKey.trim()}
-                        className="w-full rounded-xl bg-stone-900 px-4 py-2 text-xs font-bold text-white transition-colors hover:bg-black disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-stone-900 dark:hover:bg-stone-100 sm:w-auto"
-                      >
-                        保存 Key
-                      </button>
-                    </div>
-                  </div>
-                </WorkspaceSettingRow>
+                  </WorkspaceSettingRow>
+                ) : null}
 
                 <WorkspaceSettingRow
                   title="连接测试"

--- a/tests/backend/unit/llm/test_litellm_gateway.py
+++ b/tests/backend/unit/llm/test_litellm_gateway.py
@@ -146,6 +146,34 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
 
         self.assertEqual(completion.models, ["deepseek/deepseek-v4-pro"])
 
+    def test_allows_ollama_without_api_key(self) -> None:
+        completion = CapturingCompletion("ok")
+        gateway = LiteLLMCompletionGateway(
+            provider="ollama",
+            model="qwen2.5:7b",
+            base_url="http://127.0.0.1:11434",
+            api_key="",
+            completion_fn=completion,
+            acompletion_fn=unused_async_completion,
+        )
+
+        gateway.complete_text([{"role": "user", "content": "ping"}])
+
+        self.assertEqual(completion.models, ["ollama/qwen2.5:7b"])
+        self.assertEqual(completion.api_keys, [None])
+        self.assertEqual(completion.api_bases, ["http://127.0.0.1:11434"])
+
+    def test_keeps_api_key_required_for_openai_provider(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "缺少 API Key"):
+            LiteLLMCompletionGateway(
+                provider="openai",
+                model="test-model",
+                base_url="https://example.invalid/v1",
+                api_key="",
+                completion_fn=CapturingCompletion("ok"),
+                acompletion_fn=unused_async_completion,
+            )
+
     def test_falls_back_to_json_object_when_schema_is_rejected(self) -> None:
         completion = RejectingFirstResponseFormatCompletion(
             SeriesAnswerPayload,
@@ -324,6 +352,7 @@ class CapturingCompletion:
         self.reasoning_efforts: list[object] = []
         self.allowed_openai_params: list[object] = []
         self.models: list[str] = []
+        self.api_keys: list[object] = []
 
     def __call__(self, **kwargs):
         self.messages.append(list(kwargs["messages"]))
@@ -332,6 +361,7 @@ class CapturingCompletion:
         self.reasoning_efforts.append(kwargs.get("reasoning_effort"))
         self.allowed_openai_params.append(kwargs.get("allowed_openai_params"))
         self.models.append(kwargs["model"])
+        self.api_keys.append(kwargs.get("api_key"))
         return {"choices": [{"message": {"content": self._content}}]}
 
 

--- a/tests/frontend/features/workspace/model/providerRequestUrl.test.js
+++ b/tests/frontend/features/workspace/model/providerRequestUrl.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildOpenAICompatibleChatCompletionsUrl } from "@src/features/workspace/model/providerRequestUrl";
+import {
+  buildOpenAICompatibleChatCompletionsUrl,
+  buildProviderRequestPreviewUrl,
+} from "@src/features/workspace/model/providerRequestUrl";
 
 describe("buildOpenAICompatibleChatCompletionsUrl", () => {
   it("adds v1 and chat completions path for a root provider url", () => {
@@ -11,6 +14,26 @@ describe("buildOpenAICompatibleChatCompletionsUrl", () => {
   it("does not duplicate an existing version suffix", () => {
     expect(buildOpenAICompatibleChatCompletionsUrl("https://jiuuij.de5.net/v1/")).toBe(
       "https://jiuuij.de5.net/v1/chat/completions",
+    );
+  });
+});
+
+describe("buildProviderRequestPreviewUrl", () => {
+  it("uses OpenAI-compatible chat completions URLs for OpenAI providers", () => {
+    expect(buildProviderRequestPreviewUrl("openai", "https://api.example.com")).toBe(
+      "https://api.example.com/v1/chat/completions",
+    );
+  });
+
+  it("uses Ollama native generate URLs for Ollama provider", () => {
+    expect(buildProviderRequestPreviewUrl("ollama", "http://127.0.0.1:11434")).toBe(
+      "http://127.0.0.1:11434/api/generate",
+    );
+  });
+
+  it("previews the default Ollama native endpoint when the base URL is empty", () => {
+    expect(buildProviderRequestPreviewUrl("ollama", "")).toBe(
+      "http://127.0.0.1:11434/api/generate",
     );
   });
 });

--- a/tests/frontend/features/workspace/ui/WorkspaceSettingsPanel.test.jsx
+++ b/tests/frontend/features/workspace/ui/WorkspaceSettingsPanel.test.jsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorkspaceSettingsPanel } from "@src/features/workspace/ui/WorkspaceSettingsPanel";
+import { defaultUiSettings } from "@src/features/workspace/model/workspaceState";
+
+function renderPanel(uiOverrides = {}) {
+  return render(
+    <WorkspaceSettingsPanel
+      ui={{
+        ...defaultUiSettings,
+        ...uiOverrides,
+      }}
+      initialTab="keys"
+      fasterWhisperModels={[]}
+      fasterWhisperModelsLoading={false}
+      ragModels={[]}
+      onChangeSetting={vi.fn()}
+      onSaveProviderSettings={vi.fn()}
+      onSaveApiKey={vi.fn()}
+      onRevealOpenaiApiKey={vi.fn()}
+      onTestProviderConnection={vi.fn()}
+      onDownloadFasterWhisperModel={vi.fn()}
+      onDownloadRagModel={vi.fn()}
+      onResetSettings={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  );
+}
+
+describe("WorkspaceSettingsPanel provider settings", () => {
+  it("hides the API key editor for Ollama while showing the provider-native request preview", () => {
+    renderPanel({
+      llmProvider: "ollama",
+      openaiBaseUrl: "http://127.0.0.1:11434",
+      openaiModel: "qwen2.5:7b",
+    });
+
+    expect(screen.queryByText("API Key")).not.toBeInTheDocument();
+    expect(screen.queryByText("保存 Key")).not.toBeInTheDocument();
+    expect(screen.getByText("http://127.0.0.1:11434/api/generate")).toBeInTheDocument();
+  });
+
+  it("previews the default Ollama native URL when base URL is empty", () => {
+    renderPanel({
+      llmProvider: "ollama",
+      openaiBaseUrl: "",
+      openaiModel: "qwen2.5:7b",
+    });
+
+    expect(screen.getByText("http://127.0.0.1:11434/api/generate")).toBeInTheDocument();
+  });
+
+  it("shows the API key editor for OpenAI-compatible providers", () => {
+    renderPanel({
+      llmProvider: "openai",
+      openaiBaseUrl: "https://api.example.com",
+      openaiModel: "gpt-5.4",
+    });
+
+    expect(screen.getByText("API Key")).toBeInTheDocument();
+    expect(screen.getByText("保存 Key")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add provider-aware base URL resolution so Ollama uses its native API root while OpenAI-compatible providers keep `/v1` behavior.
- Allow Ollama to run without an API key while preserving key requirements for other providers.
- Hide API key controls for Ollama and show provider-specific request previews in settings.

## Test Plan
- [x] `python -m pytest tests\backend\unit\settings\test_workspace_settings_service.py tests\backend\unit\llm\test_litellm_gateway.py`
- [x] `npm test -- WorkspaceSettingsPanel.test.jsx providerRequestUrl.test.js workspaceSettingsActions.test.js`
- [x] Manual Ollama check with `qwen2.5:7b` for both `openai` and `ollama` providers

Closes #20