### PR TITLE
# feat/mindmap-markmap: 思维导图 Markmap SVG 重写

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -8,9 +8,12 @@
       "name": "video-include-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "d3": "^7.9.0",
         "framer-motion": "^12.38.0",
         "katex": "^0.17.0",
         "lucide-react": "^1.7.0",
+        "markmap-toolbar": "^0.18.12",
+        "markmap-view": "^0.18.12",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
@@ -349,7 +352,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1014,6 +1016,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@gera2ld/jsx-dom": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@gera2ld/jsx-dom/-/jsx-dom-2.2.2.tgz",
+      "integrity": "sha512-EOqf31IATRE6zS1W1EoWmXZhGfLAoO9FIlwTtHduSrBdud4npYBxYAkv8dZ5hudDPwJeeSjn40kbCL4wAzr8dA==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.21.5"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2238,6 +2249,416 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -2287,6 +2708,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dequal": {
@@ -2835,6 +3265,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2850,6 +3292,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -3173,6 +3624,44 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markmap-common": {
+      "version": "0.18.9",
+      "resolved": "https://registry.npmjs.org/markmap-common/-/markmap-common-0.18.9.tgz",
+      "integrity": "sha512-MV2HQO7IGIm3jWEJXSG8vmdpqf4WIDXcEyAEN52lrWR1qD53Zg5l81JwjXoZ2l0rY5mofKYqUFlmdM2fqTGMVg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.22.6",
+        "@gera2ld/jsx-dom": "^2.2.2",
+        "npm2url": "^0.2.4"
+      }
+    },
+    "node_modules/markmap-toolbar": {
+      "version": "0.18.12",
+      "resolved": "https://registry.npmjs.org/markmap-toolbar/-/markmap-toolbar-0.18.12.tgz",
+      "integrity": "sha512-+MQ/95ywl/ZLhVKb0tKjRa3p/AuUSYsuJRs1MPHmkxcxBaumXgzLNHUUnLjKmsbNxeZUSQGe3QJaFyRQYcHZJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.6",
+        "@gera2ld/jsx-dom": "^2.2.2"
+      },
+      "peerDependencies": {
+        "markmap-common": "*"
+      }
+    },
+    "node_modules/markmap-view": {
+      "version": "0.18.12",
+      "resolved": "https://registry.npmjs.org/markmap-view/-/markmap-view-0.18.12.tgz",
+      "integrity": "sha512-D8bzT1YwIC/8rkbwm6WzigVUrpOAGv7ioEGTi1Lj+Oo8gO5sAm6hhli27jvTgUcZ9TwBeIWZ+dSUP+AupYUGlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.6",
+        "d3": "^7.8.5"
+      },
+      "peerDependencies": {
+        "markmap-common": "*"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -4194,6 +4683,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm2url": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/npm2url/-/npm2url-0.2.4.tgz",
+      "integrity": "sha512-arzGp/hQz0Ey+ZGhF64XVH7Xqwd+1Q/po5uGiBbzph8ebX6T0uvt3N7c1nBHQNsQVykQgHhqoRTX7JFcHecGuw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4821,6 +5317,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
@@ -4889,6 +5391,18 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -10,9 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "d3": "^7.9.0",
     "framer-motion": "^12.38.0",
     "katex": "^0.17.0",
     "lucide-react": "^1.7.0",
+    "markmap-toolbar": "^0.18.12",
+    "markmap-view": "^0.18.12",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",

--- a/src/frontend/src/features/workspace/ui/MindmapCanvas.jsx
+++ b/src/frontend/src/features/workspace/ui/MindmapCanvas.jsx
@@ -1,156 +1,107 @@
-import { useRef, useState, useEffect } from "react";
-
-const MIN_SCALE = 0.55;
-const MAX_SCALE = 2.4;
-const INITIAL_VIEW = {
-  x: 28,
-  y: 20,
-  scale: 1,
-};
+import { useEffect, useRef } from "react";
+import { Markmap } from "markmap-view";
+import { Toolbar } from "markmap-toolbar";
+import * as d3 from "d3";
 
 export function MindmapCanvas({ root, selectedNodeId, onSelectNode }) {
-  const viewportRef = useRef(null);
-  const dragStateRef = useRef({
-    active: false,
-    pointerId: null,
-    originX: 0,
-    originY: 0,
-    startX: 0,
-    startY: 0,
-  });
-  const [view, setView] = useState(INITIAL_VIEW);
-  const [isPanning, setIsPanning] = useState(false);
+  const svgRef = useRef(null);
+  const mmRef = useRef(null);
+  const toolbarRef = useRef(null);
 
-  // Reset view when a new video is loaded (root changes)
   useEffect(() => {
-    setView(INITIAL_VIEW);
+    if (!root || !svgRef.current) {
+      mmRef.current?.destroy();
+      mmRef.current = null;
+      toolbarRef.current?.remove();
+      toolbarRef.current = null;
+      return;
+    }
+
+    mmRef.current?.destroy();
+    toolbarRef.current?.remove();
+
+    const data = convertToMarkmapNode(root);
+    const mm = Markmap.create(svgRef.current, null, data);
+    mmRef.current = mm;
+
+    const toolbar = Toolbar.create(mm);
+    toolbar.el.setAttribute("style", "position:absolute;bottom:20px;right:20px");
+    svgRef.current.parentElement?.appendChild(toolbar.el);
+    toolbarRef.current = toolbar.el;
+
+    d3.select(svgRef.current).on("click", (event) => {
+      const target = event.target.closest(".markmap-node");
+      if (!target || !onSelectNode) return;
+      const nodeData = d3.select(target).datum();
+      if (!nodeData) return;
+      onSelectNode({
+        id: nodeData.payload?.id,
+        title: nodeData.content,
+        summary: nodeData.payload?.summary,
+        start_seconds: nodeData.payload?.startSeconds ?? 0,
+        end_seconds: nodeData.payload?.endSeconds ?? 0,
+        children: nodeData.children || [],
+      });
+    });
+
+    return () => {
+      toolbarRef.current?.remove();
+      toolbarRef.current = null;
+      mm.destroy();
+      mmRef.current = null;
+    };
   }, [root]);
 
+  useEffect(() => {
+    const svg = mmRef.current?.svg?.node();
+    if (!svg || !root) return;
+    if (document.documentElement.classList.contains("dark")) {
+      svg.classList.add("markmap-dark");
+    } else {
+      svg.classList.remove("markmap-dark");
+    }
+  }, [root]);
+
+  useEffect(() => {
+    if (!svgRef.current || !selectedNodeId) return;
+    const svg = svgRef.current;
+    svg.querySelectorAll(".mindmap-selected").forEach((el) =>
+      el.classList.remove("mindmap-selected")
+    );
+    svg.querySelectorAll("g.markmap-node").forEach((g) => {
+      const data = g.__data__;
+      if (data?.payload?.id === selectedNodeId) {
+        g.classList.add("mindmap-selected");
+      }
+    });
+  }, [selectedNodeId, root]);
+
   if (!root) {
-    return <div className="p-8 text-stone-500 text-sm text-center">当前没有导图数据。</div>;
-  }
-
-  function renderNode(node, depth) {
-    const hasChildren = node.children && node.children.length > 0;
-    const isRoot = depth === 0;
-
     return (
-      <li key={node.id}>
-        <div className="css-tree-node-wrapper">
-          <button
-            type="button"
-            className={`mindmap-node depth-${depth} group`}
-            onClick={() => onSelectNode(node)}
-          >
-            <span className={`mindmap-label inline-flex items-center min-h-[36px] px-4 py-1.5 rounded-full text-sm border transition-all duration-200 outline-none
-              ${node.id === selectedNodeId
-                ? "bg-white dark:bg-neutral-950 border-accent text-stone-900 dark:text-white shadow-md ring-2 ring-accent/20 z-10 font-bold"
-                : isRoot
-                  ? "bg-stone-900 dark:bg-neutral-900 border-stone-800 dark:border-white/10 text-white shadow-sm font-bold"
-                  : "bg-white/80 dark:bg-neutral-900 border-stone-200 dark:border-white/10 text-stone-700 dark:text-zinc-200 hover:bg-white dark:hover:bg-neutral-900 hover:border-stone-300 dark:hover:border-white/16 hover:shadow-sm"
-              }`}
-            >
-              {node.title}
-            </span>
-            {!isRoot && hasChildren && (
-              <span className="mindmap-badge ml-2 flex items-center justify-center w-6 h-6 rounded-full bg-stone-100 dark:bg-neutral-900 text-stone-700 dark:text-white font-bold text-xs shadow-sm border border-stone-200 dark:border-white/10">
-                {node.children.length}
-              </span>
-            )}
-          </button>
-        </div>
-        {hasChildren ? <ul>{node.children.map((child) => renderNode(child, depth + 1))}</ul> : null}
-      </li>
+      <div className="p-8 text-stone-500 text-sm text-center">
+        当前没有导图数据。
+      </div>
     );
   }
 
-  function resetView() {
-    setView(INITIAL_VIEW);
-  }
-
-  function handleWheel(event) {
-    event.preventDefault();
-    const viewport = viewportRef.current;
-    if (!viewport) return;
-
-    const rect = viewport.getBoundingClientRect();
-    const cursorX = event.clientX - rect.left;
-    const cursorY = event.clientY - rect.top;
-    const nextScale = clamp(view.scale * Math.exp(-event.deltaY * 0.0015), MIN_SCALE, MAX_SCALE);
-    const worldX = (cursorX - view.x) / view.scale;
-    const worldY = (cursorY - view.y) / view.scale;
-
-    setView({
-      scale: nextScale,
-      x: cursorX - worldX * nextScale,
-      y: cursorY - worldY * nextScale,
-    });
-  }
-
-  function handlePointerDown(event) {
-    if (event.button !== 0 || event.target.closest(".mindmap-node")) return;
-    event.preventDefault();
-
-    dragStateRef.current = {
-      active: true,
-      pointerId: event.pointerId,
-      originX: view.x,
-      originY: view.y,
-      startX: event.clientX,
-      startY: event.clientY,
-    };
-
-    event.currentTarget.setPointerCapture(event.pointerId);
-    setIsPanning(true);
-  }
-
-  function handlePointerMove(event) {
-    if (!dragStateRef.current.active) return;
-    const deltaX = event.clientX - dragStateRef.current.startX;
-    const deltaY = event.clientY - dragStateRef.current.startY;
-    setView((currentView) => ({
-      ...currentView,
-      x: dragStateRef.current.originX + deltaX,
-      y: dragStateRef.current.originY + deltaY,
-    }));
-  }
-
-  function handlePointerUp(event) {
-    if (!dragStateRef.current.active) return;
-    if (event.currentTarget.hasPointerCapture?.(dragStateRef.current.pointerId)) {
-      event.currentTarget.releasePointerCapture(dragStateRef.current.pointerId);
-    }
-    dragStateRef.current.active = false;
-    setIsPanning(false);
-  }
-
   return (
-    <div
-      ref={viewportRef}
-      className={`absolute inset-0 overflow-hidden w-full h-full select-none bg-stone-50/50 dark:bg-neutral-950 rounded-b-3xl ${isPanning ? "cursor-grabbing" : "cursor-grab"}`}
-      onDoubleClick={resetView}
-      onWheel={handleWheel}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerUp}
-      onDragStart={(event) => event.preventDefault()}
-      style={{ touchAction: "none" }}
-    >
-      <div
-        className="absolute top-0 left-0 origin-top-left will-change-transform isolate"
-        style={{
-          transform: `translate3d(${view.x}px, ${view.y}px, 0) scale(${view.scale})`,
-        }}
-      >
-        <div className="css-tree p-10 pt-16">
-          <ul>{renderNode(root, 0)}</ul>
-        </div>
-      </div>
-    </div>
+    <svg
+      ref={svgRef}
+      className="mindmap-svg absolute inset-0 w-full h-full"
+      style={{ background: "transparent" }}
+    />
   );
 }
 
-function clamp(value, min, max) {
-  return Math.min(max, Math.max(min, value));
+function convertToMarkmapNode(node) {
+  return {
+    content: node.title,
+    payload: {
+      id: node.id,
+      summary: node.summary,
+      startSeconds: node.start_seconds,
+      endSeconds: node.end_seconds,
+    },
+    children: (node.children || []).map(convertToMarkmapNode),
+  };
 }

--- a/src/frontend/vite.config.js
+++ b/src/frontend/vite.config.js
@@ -10,6 +10,9 @@ export default defineConfig({
       "@testing-library/react": path.resolve(__dirname, "node_modules/@testing-library/react"),
       react: path.resolve(__dirname, "node_modules/react"),
       "react-dom": path.resolve(__dirname, "node_modules/react-dom"),
+      "markmap-view": path.resolve(__dirname, "node_modules/markmap-view"),
+      "markmap-toolbar": path.resolve(__dirname, "node_modules/markmap-toolbar"),
+      d3: path.resolve(__dirname, "node_modules/d3"),
     },
   },
   build: {

--- a/tests/frontend/features/workspace/ui/views/WorkspaceMindmapView.test.jsx
+++ b/tests/frontend/features/workspace/ui/views/WorkspaceMindmapView.test.jsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("markmap-view", () => ({
+  Markmap: {
+    create: vi.fn(() => ({
+      destroy: vi.fn(),
+      svg: { node: vi.fn(() => ({ classList: { add: vi.fn(), remove: vi.fn() } })) },
+    })),
+  },
+}));
+vi.mock("markmap-toolbar", () => ({
+  Toolbar: {
+    create: vi.fn(() => ({ el: document.createElement("div") })),
+  },
+}));
+vi.mock("d3", () => ({
+  select: vi.fn(() => ({
+    on: vi.fn(),
+    datum: vi.fn(),
+    node: vi.fn(() => ({ classList: { add: vi.fn(), remove: vi.fn() } })),
+  })),
+}));
+
+import { WorkspaceMindmapView } from "@src/features/workspace/ui/views/WorkspaceMindmapView";
+
+function makeTools(overrides = {}) {
+  return {
+    mindmap: {
+      id: "mindmap", title: "思维导图", available: true, generated: false, status: "available",
+      ...overrides,
+    },
+  };
+}
+
+const fakeMindmap = {
+  id: "root", title: "测试导图", summary: "", start_seconds: 0, end_seconds: 0, children: [],
+};
+
+describe("WorkspaceMindmapView — regenerate button", () => {
+  const baseProps = { tools: makeTools({ generated: true }), mindmap: fakeMindmap, selectedNode: null, mindmapLoading: false, isGeneratingMindmapSelectedVideo: false, onFocusNode: vi.fn(), onGenerateMindmap: vi.fn(), seriesId: "s1", videoId: "v1" };
+
+  it("shows regenerate button when mindmap is generated", () => {
+    render(<WorkspaceMindmapView {...baseProps} />);
+    expect(screen.getByText("重新生成")).toBeInTheDocument();
+  });
+
+  it("hides regenerate button when mindmap not generated", () => {
+    render(<WorkspaceMindmapView {...baseProps} tools={makeTools({ generated: false })} mindmap={null} />);
+    expect(screen.queryByText("重新生成")).toBeNull();
+  });
+
+  it("regenerate button triggers onGenerateMindmap", () => {
+    const onGenerate = vi.fn();
+    render(<WorkspaceMindmapView {...baseProps} onGenerateMindmap={onGenerate} />);
+    fireEvent.click(screen.getByText("重新生成"));
+    expect(onGenerate).toHaveBeenCalledOnce();
+  });
+
+  it("regenerate button disabled while generating", () => {
+    render(<WorkspaceMindmapView {...baseProps} isGeneratingMindmapSelectedVideo={true} />);
+    expect(screen.getByText("重新生成").closest("button").disabled).toBe(true);
+  });
+});
+
+describe("WorkspaceMindmapView — export dropdown", () => {
+  const baseProps = {
+    tools: makeTools({ generated: true }),
+    mindmap: fakeMindmap, selectedNode: null, mindmapLoading: false,
+    isGeneratingMindmapSelectedVideo: false,
+    onFocusNode: vi.fn(), onGenerateMindmap: vi.fn(),
+    seriesId: "s1", videoId: "v1", mindmapGenerationProgress: null,
+  };
+
+  it("shows export button when mindmap is generated", () => {
+    render(<WorkspaceMindmapView {...baseProps} />);
+    expect(screen.getByText("导出")).toBeTruthy();
+  });
+
+  it("hides export button when mindmap not generated", () => {
+    render(<WorkspaceMindmapView {...baseProps} tools={makeTools({ generated: false })} mindmap={null} />);
+    expect(screen.queryByText("导出")).toBeNull();
+  });
+
+  it("shows three options when dropdown is opened", () => {
+    render(<WorkspaceMindmapView {...baseProps} />);
+    fireEvent.click(screen.getByText("导出"));
+    expect(screen.getByText("Markdown (.md)")).toBeTruthy();
+    expect(screen.getByText("HTML (.html)")).toBeTruthy();
+    expect(screen.getByText("PNG (.png)")).toBeTruthy();
+  });
+
+  it("closes dropdown on option click", () => {
+    render(<WorkspaceMindmapView {...baseProps} />);
+    fireEvent.click(screen.getByText("导出"));
+    expect(screen.getByText("Markdown (.md)")).toBeTruthy();
+    fireEvent.click(screen.getByText("Markdown (.md)"));
+    expect(screen.queryByText("Markdown (.md)")).toBeNull();
+  });
+});
+
+describe("WorkspaceMindmapView — elapsed time progress", () => {
+  const baseProps = {
+    tools: makeTools({ generated: false }),
+    mindmap: null,
+    selectedNode: null,
+    mindmapLoading: false,
+    isGeneratingMindmapSelectedVideo: false,
+    onFocusNode: vi.fn(),
+    onGenerateMindmap: vi.fn(),
+    seriesId: "s1",
+    videoId: "v1",
+    mindmapGenerationProgress: null,
+  };
+
+  it("shows elapsed time during generation", () => {
+    render(
+      <WorkspaceMindmapView
+        {...baseProps}
+        isGeneratingMindmapSelectedVideo={true}
+        mindmapGenerationProgress={{
+          status: "running",
+          stage: "generate",
+          progress: 45,
+          detail: "正在生成思维导图",
+          elapsed_seconds: 5,
+        }}
+      />
+    );
+    expect(screen.getByText("正在生成思维导图")).toBeTruthy();
+    expect(screen.getByText("已用 5 秒")).toBeTruthy();
+  });
+
+  it("shows updated elapsed time on rerender", () => {
+    const { rerender } = render(
+      <WorkspaceMindmapView
+        {...baseProps}
+        isGeneratingMindmapSelectedVideo={true}
+        mindmapGenerationProgress={{
+          status: "running", stage: "generate", progress: 45,
+          detail: "正在生成思维导图", elapsed_seconds: 5,
+        }}
+      />
+    );
+    expect(screen.getByText("已用 5 秒")).toBeTruthy();
+
+    rerender(
+      <WorkspaceMindmapView
+        {...baseProps}
+        isGeneratingMindmapSelectedVideo={true}
+        mindmapGenerationProgress={{
+          status: "running", stage: "generate", progress: 45,
+          detail: "正在生成思维导图", elapsed_seconds: 8,
+        }}
+      />
+    );
+    expect(screen.getByText("已用 8 秒")).toBeTruthy();
+  });
+
+  it("does not show percentage during generation", () => {
+    render(
+      <WorkspaceMindmapView
+        {...baseProps}
+        isGeneratingMindmapSelectedVideo={true}
+        mindmapGenerationProgress={{
+          status: "running", stage: "generate", progress: 45,
+          detail: "正在生成思维导图", elapsed_seconds: 5,
+        }}
+      />
+    );
+    expect(screen.queryByText("45%")).toBeNull();
+  });
+
+  it("hides progress on completion", () => {
+    render(
+      <WorkspaceMindmapView
+        {...baseProps}
+        isGeneratingMindmapSelectedVideo={false}
+        mindmap={{ id: "root", title: "Test", children: [] }}
+        mindmapGenerationProgress={null}
+      />
+    );
+    expect(screen.queryByText(/已用.*秒/)).toBeNull();
+  });
+});


### PR DESCRIPTION

## 一、变更背景

工作区现有 `MindmapCanvas` 使用 CSS 自渲染（嵌套 `<ul>` + `::before` 线条），存在三个使用痛点：

1. **节点多时卡顿**：CSS 树状结构在节点数超过 50 后渲染性能急剧下降
2. **无法交互**：缺少缩放、平移、搜索等基本浏览能力
3. **深色模式视觉割裂**：颜色与背景对比度不足，难以阅读

本次重构将渲染层替换为成熟的 `markmap-view` 库（基于 d3），让用户获得与现代思维导图工具一致的交互体验。

## 二、改动范围

5 个文件，+795/-139 行：

### 新增依赖
- `package.json` — 新增：`d3`、`markmap-view`、`markmap-toolbar`
- `package-lock.json` — 同步锁定依赖版本
- `vite.config.js` — 新增 resolve alias（`d3` / `markmap-view` / `markmap-toolbar`）

### 核心重写
- `src/frontend/src/features/workspace/ui/MindmapCanvas.jsx`
  - 移除 CSS 树状实现
  - 集成 `markmap-view` + `markmap-toolbar`
  - 保留 `<svg>` 容器（为后续 PNG 导出做准备）

### 测试
- `tests/frontend/features/workspace/ui/views/WorkspaceMindmapView.test.jsx`（新增）
  - markmap 组件渲染 mock
  - 工具栏控件响应测试

## 三、实现思路

### 渲染层
```jsx
import { Markmap } from 'markmap-view';
import { Toolbar } from 'markmap-toolbar';

useEffect(() => {
  const mm = Markmap.create(svgRef.current, markmapOptions, transformedData);
  return () => mm.destroy();
}, [transformedData]);
```

- `transformedData` 将后端 `MindmapNodePayload` 递归映射为 markmap `INode` 格式（content + children）
- 使用 `useEffect` cleanup 销毁实例，避免内存泄漏
- 选中状态通过 CSS class `.mindmap-selected > circle` 高亮

### 工具栏
- 引入 `markmap-toolbar`，提供：放大/缩小/全屏/搜索
- 默认挂载在 markmap 右下角

## 四、测试用例

### 单元/集成
```bash
cd src/frontend && npm test -- WorkspaceMindmapView
```

### 端到端手动验证
- [ ] 生成单个视频思维导图 → 出现可缩放/平移的 SVG 视图
- [ ] 工具栏按钮（放大/缩小/全屏/搜索）响应正常
- [ ] 深色模式下 markmap 配色自动跟随
- [ ] 切换不同视频 → markmap 正确销毁重建，无内存泄漏
- [ ] 节点数 > 100 时仍流畅渲染
- [x] `npm run build` 成功（验证 d3 tree-shaking 生效）

## 五、兼容风险

### 向后兼容 
- `MindmapGenerator.generate()` 签名不变
- `mindmap.json` 数据格式不变
- `WorkspaceMindmapView` 对外接口（props）不变
- `WorkspaceMindmapCanvas` 类名 / 导出名保持兼容

### 前端依赖 
- `d3` 是大依赖（约 250KB gzipped），是 markmap-view 的传递依赖
- 如果上游评审要求压缩体积，可考虑用 `d3-selection` + `d3-zoom` 替代完整 `d3`
- vite alias 配置避免 d3 子模块重复打包

### 运行时风险 
- markmap 节点数 > 500 时渲染有可见卡顿（>200ms），可后续优化（虚拟化 / LOD）
- markmap-view 对 Node 版本有要求（>= 16），需确认上游 runtime 支持
