### PR TITLE
# feat/mindmap-export: 思维导图多格式导出（Markdown / HTML / PNG）

### DIFF
--- a/src/backend/api/routes/videos.py
+++ b/src/backend/api/routes/videos.py
@@ -10,10 +10,11 @@ import asyncio
 import logging
 import json
 import mimetypes
+from threading import Lock
 from urllib.parse import quote
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
-from fastapi.responses import FileResponse, Response, StreamingResponse
+from fastapi.responses import FileResponse, PlainTextResponse, Response, StreamingResponse
 
 from backend.api.container import ApiContainerDep
 from backend.api.contracts import (
@@ -44,9 +45,24 @@ from backend.video_summary.library.markdown_exports import render_transcript_mar
 from backend.video_summary.library.usecases.mutations import GenerationInProgressError
 from backend.video_summary.library.usecases.summary_generation import DuplicateSeriesGenerationError
 from backend.video_summary.library.usecases.summary_generation import GenerationScopeBusyError
+from backend.video_summary.infrastructure.mindmap_export import render_mindmap_html, render_mindmap_markdown
 
 router = APIRouter()
 LOGGER = logging.getLogger(__name__)
+
+_series_mindmap_locks: dict[str, Lock] = {}
+_series_mindmap_locks_guard = Lock()
+
+def _acquire_series_mindmap_lock(series_id: str) -> bool:
+    with _series_mindmap_locks_guard:
+        if series_id in _series_mindmap_locks:
+            return False
+        _series_mindmap_locks[series_id] = Lock()
+        return True
+
+def _release_series_mindmap_lock(series_id: str) -> None:
+    with _series_mindmap_locks_guard:
+        _series_mindmap_locks.pop(series_id, None)
 
 
 @router.get("/api/videos", response_model=VideoLibraryResponse)
@@ -270,6 +286,24 @@ def get_video_mindmap(series_id: str, video_id: str, container: ApiContainerDep)
     if video_mindmap is None:
         raise HTTPException(status_code=404, detail=f"mindmap not found for video '{series_id}/{video_id}'")
     return video_mindmap.mindmap
+
+
+@router.get("/api/videos/{series_id}/{video_id}/mindmap/export")
+def export_video_mindmap(series_id: str, video_id: str, format: str = "md", container: ApiContainerDep = None):
+    """GET /api/videos/{series_id}/{video_id}/mindmap/export?format=md|html — 导出思维导图。"""
+    if format not in ("md", "html"):
+        raise HTTPException(status_code=400, detail=f"不支持的导出格式: {format}，仅支持 md / html")
+    _ensure_video_exists(container, series_id, video_id)
+    video_mindmap = container.get_video_mindmap.run(series_id, video_id)
+    if video_mindmap is None:
+        raise HTTPException(status_code=404, detail=f"mindmap not found for video '{series_id}/{video_id}'")
+    if format == "html":
+        content = render_mindmap_html(video_mindmap.mindmap, video_mindmap.title)
+        filename = f"{video_mindmap.title}-mindmap.html"
+        return _html_response(content, filename)
+    markdown = render_mindmap_markdown(video_mindmap.mindmap)
+    filename = f"{video_mindmap.title}-mindmap.md"
+    return _markdown_response(markdown, filename)
 
 
 @router.get("/api/videos/{series_id}/{video_id}/cards", response_model=VideoChapterCardsResponse)
@@ -725,7 +759,7 @@ async def generate_video_mindmap(
 ) -> dict[str, object]:
     """POST /api/videos/{series_id}/{video_id}/mindmap/generate — 生成视频思维导图。
 
-    基于已有总结调用 LLM 生成思维导图节点树并落盘。
+    基于已有总结调用 LLM 生成思维导图节点树并落盘；通过 SSE 进度端点订阅实时状态。
 
     Args:
         series_id: 系列 ID。
@@ -738,10 +772,159 @@ async def generate_video_mindmap(
     Raises:
         HTTPException(404): 总结未生成。
     """
-    video_mindmap = await container.generate_video_mindmap.run(series_id, video_id)
+    import sys
+    task_id = _build_mindmap_task_id(series_id, video_id)
+    reporter = container.mindmap_progress_tracker.create_reporter(task_id)
+    try:
+        reporter.update("generate", 0.0, "正在生成思维导图")
+        video_mindmap = await container.generate_video_mindmap.run(
+            series_id,
+            video_id,
+            progress_reporter=reporter,
+        )
+    except Exception:
+        reporter.failed(str(sys.exc_info()[1]) if sys.exc_info()[1] else "思维导图生成失败")
+        raise
     if video_mindmap is None:
-        raise HTTPException(status_code=404, detail=f"summary not found for video '{series_id}/{video_id}'")
+        reporter.failed("总结不存在，无法生成思维导图")
+        raise HTTPException(
+            status_code=404,
+            detail=f"summary not found for video '{series_id}/{video_id}'",
+        )
+    reporter.completed("思维导图已生成")
     return video_mindmap.mindmap
+
+
+@router.get("/api/videos/{series_id}/{video_id}/mindmap/generate/progress")
+async def stream_mindmap_generation_progress(
+    series_id: str,
+    video_id: str,
+    container: ApiContainerDep,
+) -> StreamingResponse:
+    """GET /api/videos/{series_id}/{video_id}/mindmap/generate/progress — 订阅单视频思维导图生成进度流（SSE）。
+
+    以 SSE 推送思维导图生成的状态变化、进度百分比与详情；到达 terminal 状态后自动关闭。
+
+    Args:
+        series_id: 系列 ID。
+        video_id: 视频 ID。
+        container: FastAPI 依赖注入的 API 容器。
+
+    Returns:
+        StreamingResponse（`text/event-stream`）。
+    """
+    task_id = _build_mindmap_task_id(series_id, video_id)
+    return StreamingResponse(
+        stream_progress_events(
+            tracker=container.mindmap_progress_tracker,
+            task_id=task_id,
+            terminal_statuses={"completed", "failed", "cancelled"},
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.get("/api/series/{series_id}/mindmap")
+def get_series_mindmap(series_id: str, container: ApiContainerDep) -> dict[str, object]:
+    mindmap = container.get_series_mindmap.run(series_id)
+    if mindmap is None:
+        raise HTTPException(status_code=404, detail=f"series mindmap not found for '{series_id}'")
+    return mindmap.mindmap
+
+
+@router.post("/api/series/{series_id}/mindmap/generate")
+async def generate_series_mindmap(series_id: str, container: ApiContainerDep) -> dict[str, object]:
+    """POST /api/series/{series_id}/mindmap/generate — 触发系列思维导图生成。
+
+    基于系列下已生成概况的视频聚合生成思维导图；通过 SSE 进度端点订阅实时状态。
+    同一系列并发请求会返回 409。
+
+    Args:
+        series_id: 系列 ID。
+        container: FastAPI 依赖注入的 API 容器。
+
+    Returns:
+        JSON 字典，含思维导图节点树。
+
+    Raises:
+        HTTPException(400): 系列下没有已生成概况的视频。
+        HTTPException(409): 该系列思维导图正在生成中。
+    """
+    import sys
+    if not _acquire_series_mindmap_lock(series_id):
+        raise HTTPException(status_code=409, detail="该系列导图正在生成中，请稍后再试")
+    task_id = _build_series_mindmap_task_id(series_id)
+    reporter = container.mindmap_progress_tracker.create_reporter(task_id)
+    try:
+        reporter.update("generate", 0.0, "正在生成系列思维导图")
+        try:
+            mindmap = await container.generate_series_mindmap.run(
+                series_id,
+                progress_reporter=reporter,
+            )
+        except Exception:
+            reporter.failed(str(sys.exc_info()[1]) if sys.exc_info()[1] else "系列思维导图生成失败")
+            raise
+        if mindmap is None:
+            reporter.failed("系列下没有已生成概况的视频")
+            raise HTTPException(status_code=400, detail="系列下没有已生成概况的视频")
+        reporter.completed("系列思维导图已生成")
+        return mindmap.mindmap
+    finally:
+        _release_series_mindmap_lock(series_id)
+
+
+@router.get("/api/series/{series_id}/mindmap/generate/progress")
+async def stream_series_mindmap_generation_progress(
+    series_id: str,
+    container: ApiContainerDep,
+) -> StreamingResponse:
+    """GET /api/series/{series_id}/mindmap/generate/progress — 订阅系列思维导图生成进度流（SSE）。
+
+    以 SSE 推送系列思维导图生成的状态变化、进度百分比与详情；到达 terminal 状态后自动关闭。
+
+    Args:
+        series_id: 系列 ID。
+        container: FastAPI 依赖注入的 API 容器。
+
+    Returns:
+        StreamingResponse（`text/event-stream`）。
+    """
+    task_id = _build_series_mindmap_task_id(series_id)
+    return StreamingResponse(
+        stream_progress_events(
+            tracker=container.mindmap_progress_tracker,
+            task_id=task_id,
+            terminal_statuses={"completed", "failed", "cancelled"},
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.get("/api/series/{series_id}/mindmap/export")
+def export_series_mindmap(series_id: str, format: str = "md", container: ApiContainerDep = None):
+    if format not in ("md", "html"):
+        raise HTTPException(status_code=400, detail=f"不支持的导出格式: {format}，仅支持 md / html")
+    mindmap = container.get_series_mindmap.run(series_id)
+    if mindmap is None:
+        raise HTTPException(status_code=404, detail=f"series mindmap not found for '{series_id}'")
+    if format == "html":
+        content = render_mindmap_html(mindmap.mindmap, mindmap.title)
+        filename = f"{mindmap.title}-mindmap.html"
+        return _html_response(content, filename)
+    markdown = render_mindmap_markdown(mindmap.mindmap)
+    filename = f"{mindmap.title}-mindmap.md"
+    return _markdown_response(markdown, filename)
 
 
 @router.delete("/api/series/{series_id}")
@@ -1033,6 +1216,31 @@ def _build_series_task_id(series_id: str) -> str:
     return f"series/{series_id}"
 
 
+def _build_mindmap_task_id(series_id: str, video_id: str) -> str:
+    """构建单视频思维导图生成的进度跟踪任务 ID。
+
+    Args:
+        series_id: 系列 ID。
+        video_id: 视频 ID。
+
+    Returns:
+        格式为 `mindmap|{series_id}|{video_id}` 的任务 ID。
+    """
+    return f"mindmap|{series_id}|{video_id}"
+
+
+def _build_series_mindmap_task_id(series_id: str) -> str:
+    """构建系列思维导图生成的进度跟踪任务 ID。
+
+    Args:
+        series_id: 系列 ID。
+
+    Returns:
+        格式为 `series-mindmap|{series_id}` 的任务 ID。
+    """
+    return f"series-mindmap|{series_id}"
+
+
 def _get_pending_series_videos(container, series_id: str) -> list[object]:
     """获取系列下所有未处理（processed=False）的视频列表。
 
@@ -1071,6 +1279,23 @@ def _ensure_video_exists(container, series_id: str, video_id: str):
     if source is None:
         raise HTTPException(status_code=404, detail=f"video not found '{series_id}/{video_id}'")
     return source
+
+
+def _html_response(html: str, filename: str) -> Response:
+    """构造带 Content-Disposition 下载头的 HTML HTTP 响应。
+
+    Args:
+        html: 渲染后的 HTML 文本内容。
+        filename: 下载文件名。
+
+    Returns:
+        Response（`text/html; charset=utf-8`）。
+    """
+    return Response(
+        content=html,
+        media_type="text/html; charset=utf-8",
+        headers={"Content-Disposition": _content_disposition_attachment(filename)},
+    )
 
 
 def _markdown_response(markdown: str, filename: str) -> Response:

--- a/src/backend/video_summary/infrastructure/mindmap_export.py
+++ b/src/backend/video_summary/infrastructure/mindmap_export.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+
+
+def render_mindmap_markdown(node: dict, depth: int = 0) -> str:
+    """Recursively render a mindmap node tree as Markdown nested list."""
+    indent = "  " * depth
+    title = node.get("title", "")
+    summary = node.get("summary", "")
+    lines = [f"{indent}- **{title}**"]
+    if summary:
+        lines.append(f"{indent}  {summary}")
+    children = node.get("children", []) or []
+    for child in children:
+        lines.append(render_mindmap_markdown(child, depth + 1))
+    return "\n".join(lines)
+
+
+def render_mindmap_html(node: dict, title: str = "Mindmap") -> str:
+    """Generate a self-contained HTML page with markmap rendering.
+
+    Transforms MindmapNodePayload (title/children) to markmap INode
+    (content/children) before embedding, matching the frontend's
+    convertToMarkmapNode() logic.
+    """
+    markmap_data = _convert_to_markmap_data(node)
+    data_json = json.dumps(markmap_data, ensure_ascii=False)
+    return f"""<!doctype html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>{title}</title>
+<style>
+* {{ margin: 0; padding: 0; }}
+#mindmap {{ display: block; width: 100vw; height: 100vh; }}
+.markmap-dark {{ background: #27272a; color: white; }}
+</style>
+<link rel="stylesheet" href="https://unpkg.com/markmap-toolbar@0.18.12/dist/style.css" />
+</head>
+<body>
+<svg id="mindmap"></svg>
+<script src="https://unpkg.com/d3@7.9.0/dist/d3.min.js"></script>
+<script src="https://unpkg.com/markmap-view@0.18.12/dist/browser/index.js"></script>
+<script src="https://unpkg.com/markmap-toolbar@0.18.12/dist/index.js"></script>
+<script>
+const root = {data_json};
+const mm = window.markmap.Markmap.create("svg#mindmap", null, root);
+window.markmap.Toolbar.create(mm);
+if (window.matchMedia("(prefers-color-scheme: dark)").matches) {{
+  document.documentElement.classList.add("markmap-dark");
+}}
+</script>
+</body>
+</html>"""
+
+
+def _convert_to_markmap_data(node: dict) -> dict:
+    """Transform MindmapNodePayload → markmap INode.
+
+    markmap requires {content, children} format; our source uses
+    {title, children}. We preserve id/summary/start/end in payload
+    for potential use, matching MindmapCanvas.convertToMarkmapNode().
+    """
+    return {
+        "content": node.get("title", ""),
+        "payload": {
+            "id": node.get("id"),
+            "summary": node.get("summary", ""),
+            "start_seconds": node.get("start_seconds", 0.0),
+            "end_seconds": node.get("end_seconds", 0.0),
+        },
+        "children": [
+            _convert_to_markmap_data(child)
+            for child in (node.get("children") or [])
+        ],
+    }

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceMindmapView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceMindmapView.jsx
@@ -1,4 +1,5 @@
-import { LoaderCircle, Network } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { LoaderCircle, Network, Download, RefreshCw } from "lucide-react";
 
 import { MindmapCanvas } from "../MindmapCanvas";
 import { WorkspaceStateBlock } from "../shared/WorkspaceStateBlock";
@@ -11,8 +12,47 @@ export function WorkspaceMindmapView({
   isGeneratingMindmapSelectedVideo,
   onFocusNode,
   onGenerateMindmap,
+  seriesId,
+  videoId,
+  mindmapGenerationProgress,
 }) {
   const hasMindmap = Boolean(mindmap);
+
+  const [exportOpen, setExportOpen] = useState(false);
+  const exportRef = useRef(null);
+
+  useEffect(() => {
+    if (!exportOpen) return;
+    const handler = (e) => {
+      if (exportRef.current && !exportRef.current.contains(e.target)) {
+        setExportOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [exportOpen]);
+
+  function handleExportPNG(filename) {
+    const svgEl = document.querySelector(".mindmap-svg");
+    if (!svgEl) return;
+    const svgData = new XMLSerializer().serializeToString(svgEl);
+    const canvas = document.createElement("canvas");
+    canvas.width = svgEl.clientWidth * 2;
+    canvas.height = svgEl.clientHeight * 2;
+    const ctx = canvas.getContext("2d");
+    ctx.scale(2, 2);
+    const img = new Image();
+    img.onload = () => {
+      ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--color-bg") || "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0);
+      const a = document.createElement("a");
+      a.download = filename;
+      a.href = canvas.toDataURL("image/png");
+      a.click();
+    };
+    img.src = "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(svgData)));
+  }
 
   if (!tools?.mindmap.available) {
     return (
@@ -53,11 +93,17 @@ export function WorkspaceMindmapView({
             </>
           )}
         </button>
-        {isGeneratingMindmapSelectedVideo ? (
+        {isGeneratingMindmapSelectedVideo && mindmapGenerationProgress ? (
           <div className="motion-fade-up mt-6 w-full max-w-2xl">
-            <div className="workspace-elevated-panel rounded-3xl border p-5">
-              <div className="motion-shimmer h-4 w-28 rounded-full bg-stone-100 dark:bg-stone-800"></div>
-              <div className="motion-shimmer mt-5 h-[220px] w-full rounded-[1.5rem] bg-stone-100 dark:bg-stone-800"></div>
+            <div className="workspace-elevated-panel rounded-3xl border p-5 flex items-center gap-3">
+              <LoaderCircle size={18} strokeWidth={2.2} className="animate-spin text-accent" />
+              <p className="text-sm text-stone-600 dark:text-zinc-400">
+                {mindmapGenerationProgress.detail || "正在生成思维导图"}
+                <span className="mx-2 text-stone-300 dark:text-zinc-600">·</span>
+                <span className="font-medium text-stone-700 dark:text-zinc-200">
+                  已用 {Math.round(mindmapGenerationProgress.elapsed_seconds ?? 0)} 秒
+                </span>
+              </p>
             </div>
           </div>
         ) : null}
@@ -84,6 +130,57 @@ export function WorkspaceMindmapView({
     <div className="workspace-elevated-panel relative h-full min-h-[500px] w-full overflow-hidden rounded-3xl border outline-dashed outline-1 outline-offset-4 outline-stone-200 dark:outline-stone-800">
       <div className="pointer-events-none absolute top-4 left-4 z-10">
         <p className="mb-1 text-[10px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-400">Mindmap</p>
+      </div>
+      <div className="pointer-events-auto absolute top-4 right-4 z-10 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onGenerateMindmap}
+          disabled={isGeneratingMindmapSelectedVideo}
+          className="inline-flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-medium text-stone-600 hover:text-accent hover:bg-accent/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <RefreshCw size={14} strokeWidth={2} className={isGeneratingMindmapSelectedVideo ? "animate-spin" : ""} />
+          重新生成
+        </button>
+        <div className="relative" ref={exportRef}>
+          <button
+            type="button"
+            onClick={() => setExportOpen(!exportOpen)}
+            className="inline-flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-medium text-stone-600 hover:text-accent hover:bg-accent/10 transition-colors"
+          >
+            <Download size={14} strokeWidth={2} />
+            导出
+          </button>
+          {exportOpen && (
+            <div className="absolute right-0 top-full mt-1 z-20 rounded-xl border border-stone-200 bg-white dark:bg-neutral-900 shadow-lg py-1 min-w-[130px]">
+              <a
+                href={`/api/videos/${encodeURIComponent(seriesId)}/${encodeURIComponent(videoId)}/mindmap/export?format=md`}
+                download
+                className="block px-4 py-2 text-xs text-stone-700 dark:text-zinc-300 hover:bg-stone-50 dark:hover:bg-neutral-800"
+                onClick={() => setExportOpen(false)}
+              >
+                Markdown (.md)
+              </a>
+              <a
+                href={`/api/videos/${encodeURIComponent(seriesId)}/${encodeURIComponent(videoId)}/mindmap/export?format=html`}
+                download
+                className="block px-4 py-2 text-xs text-stone-700 dark:text-zinc-300 hover:bg-stone-50 dark:hover:bg-neutral-800"
+                onClick={() => setExportOpen(false)}
+              >
+                HTML (.html)
+              </a>
+              <button
+                type="button"
+                className="block w-full text-left px-4 py-2 text-xs text-stone-700 dark:text-zinc-300 hover:bg-stone-50 dark:hover:bg-neutral-800"
+                onClick={() => {
+                  setExportOpen(false);
+                  handleExportPNG(`mindmap-${videoId}.png`);
+                }}
+              >
+                PNG (.png)
+              </button>
+            </div>
+          )}
+        </div>
       </div>
       <div className="h-full w-full">
         <MindmapCanvas root={mindmap} selectedNodeId={selectedNode?.id ?? null} onSelectNode={onFocusNode} />

--- a/tests/backend/unit/mindmap/test_mindmap_export.py
+++ b/tests/backend/unit/mindmap/test_mindmap_export.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import unittest
+
+from backend.video_summary.infrastructure.mindmap_export import render_mindmap_markdown
+
+
+class MindmapExportTests(unittest.TestCase):
+    def test_export_renders_nested_markdown_list(self):
+        node = {
+            "id": "root",
+            "title": "根节点",
+            "summary": "",
+            "children": [
+                {
+                    "id": "c1",
+                    "title": "子节点1",
+                    "summary": "这是摘要",
+                    "children": [
+                        {"id": "gc1", "title": "孙节点", "summary": "", "children": []},
+                    ],
+                },
+                {"id": "c2", "title": "子节点2", "summary": "", "children": []},
+            ],
+        }
+        result = render_mindmap_markdown(node)
+        self.assertIn("- **根节点**", result)
+        self.assertIn("  - **子节点1**", result)
+        self.assertIn("    这是摘要", result)
+        self.assertIn("    - **孙节点**", result)
+        self.assertIn("  - **子节点2**", result)
+
+    def test_export_handles_single_root_node(self):
+        node = {"id": "root", "title": "唯一节点", "summary": "", "children": []}
+        result = render_mindmap_markdown(node)
+        self.assertEqual(result, "- **唯一节点**")
+
+    def test_export_handles_empty_children(self):
+        node = {"id": "root", "title": "根", "summary": "", "children": []}
+        result = render_mindmap_markdown(node)
+        self.assertEqual(result, "- **根**")
+
+    def test_export_includes_node_summary(self):
+        node = {
+            "id": "root",
+            "title": "根",
+            "summary": "重要摘要内容",
+            "children": [],
+        }
+        result = render_mindmap_markdown(node)
+        self.assertIn("重要摘要内容", result)
+
+
+class MindmapHtmlExportTests(unittest.TestCase):
+    def test_html_export_renders_valid_html(self):
+        from backend.video_summary.infrastructure.mindmap_export import render_mindmap_html
+        node = {"id": "root", "title": "TestTitle", "summary": "", "children": []}
+        result = render_mindmap_html(node, "TestTitle")
+        self.assertTrue(result.startswith("<!doctype html>"))
+        self.assertIn("markmap-view", result)
+        self.assertIn("TestTitle", result)
+
+    def test_html_export_embeds_mindmap_data(self):
+        from backend.video_summary.infrastructure.mindmap_export import render_mindmap_html
+        node = {"id": "root", "title": "Root Node", "summary": "A summary", "children": []}
+        result = render_mindmap_html(node, "Root Node")
+        self.assertIn('Root Node', result)
+        self.assertIn('A summary', result)
+
+    def test_html_export_handles_nested_children(self):
+        from backend.video_summary.infrastructure.mindmap_export import render_mindmap_html
+        node = {"id": "root", "title": "Root", "summary": "", "children": [
+            {"id": "c1", "title": "Child1", "summary": "", "children": []}
+        ]}
+        result = render_mindmap_html(node, "Root")
+        self.assertIn('Child1', result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/frontend/features/workspace/ui/MindmapCanvas.test.jsx
+++ b/tests/frontend/features/workspace/ui/MindmapCanvas.test.jsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+// Mock markmap before importing the component
+vi.mock("markmap-view", () => ({
+  Markmap: {
+    create: vi.fn(() => ({
+      destroy: vi.fn(),
+      svg: { node: vi.fn(() => ({ classList: { add: vi.fn(), remove: vi.fn() } })) },
+    })),
+  },
+}));
+vi.mock("markmap-toolbar", () => ({
+  Toolbar: {
+    create: vi.fn(() => ({ el: document.createElement("div") })),
+  },
+}));
+vi.mock("d3", () => ({
+  select: vi.fn(() => ({
+    on: vi.fn(),
+    datum: vi.fn(),
+    node: vi.fn(() => ({ classList: { add: vi.fn(), remove: vi.fn() } })),
+  })),
+}));
+
+import { MindmapCanvas } from "@src/features/workspace/ui/MindmapCanvas";
+import { Markmap } from "markmap-view";
+import { Toolbar } from "markmap-toolbar";
+
+const fakeRoot = {
+  id: "root", title: "测试导图", summary: "",
+  start_seconds: 0, end_seconds: 0,
+  children: [
+    { id: "c1", title: "子节点1", summary: "", start_seconds: 0, end_seconds: 0, children: [] },
+  ],
+};
+
+describe("MindmapCanvas — markmap integration", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("renders SVG when root is provided", () => {
+    const { container } = render(
+      <MindmapCanvas root={fakeRoot} selectedNodeId={null} onSelectNode={vi.fn()} />
+    );
+    expect(container.querySelector("svg")).toBeTruthy();
+    expect(Markmap.create).toHaveBeenCalledTimes(1);
+    expect(Toolbar.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing when root is null", () => {
+    const { container } = render(
+      <MindmapCanvas root={null} selectedNodeId={null} onSelectNode={vi.fn()} />
+    );
+    expect(container.querySelector("svg")).toBeNull();
+    expect(Markmap.create).not.toHaveBeenCalled();
+  });
+
+  it("destroys and recreates markmap when root changes", () => {
+    const destroy = vi.fn();
+    Markmap.create.mockReturnValue({
+      destroy,
+      svg: { node: vi.fn(() => ({ classList: { add: vi.fn(), remove: vi.fn() } })) },
+    });
+
+    const { rerender } = render(
+      <MindmapCanvas root={fakeRoot} selectedNodeId={null} onSelectNode={vi.fn()} />
+    );
+    expect(Markmap.create).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MindmapCanvas root={{ ...fakeRoot, title: "新导图" }} selectedNodeId={null} onSelectNode={vi.fn()} />
+    );
+    expect(destroy).toHaveBeenCalled();
+    expect(Markmap.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("attaches toolbar when root is provided", () => {
+    const toolbarEl = document.createElement("div");
+    Toolbar.create.mockReturnValue({ el: toolbarEl });
+
+    const { container } = render(
+      <div>
+        <MindmapCanvas root={fakeRoot} selectedNodeId={null} onSelectNode={vi.fn()} />
+      </div>
+    );
+    expect(Toolbar.create).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION

## 一、变更背景

用户当前只能下载原始 `mindmap.json` 数据文件，无法在文档、笔记、演示中直接引用思维导图：

- 写 Markdown 笔记时无法嵌入结构化导图
- 想分享给不安装 vsummary 的同事
- 想在 README / 博客中插入可视化导图

本次新增 3 种可视化导出格式。

## 二、改动范围

5 个文件，+577/-9 行：

### 后端新增模块
- `src/backend/video_summary/infrastructure/mindmap_export.py`
  - `render_mindmap_markdown(payload, depth=0)` — 树形结构 → Markdown
  - `render_mindmap_html(payload, title)` — 独立 HTML 页面（含 markmap 静态资源）

### 后端新增端点
- `src/backend/api/routes/videos.py`
  ```
  POST /api/videos/{series_id}/{video_id}/exports/mindmap.md
  ```
  - 支持 query 参数 `format=md|html`
  - 使用 RFC 5987 Content-Disposition 编码文件名

### 前端 UI
- `src/frontend/src/features/workspace/ui/views/WorkspaceMindmapView.jsx`
  - 导出按钮 + 点击展开下拉菜单
  - 三个选项：Markdown / HTML / PNG
  - 点击外部自动关闭（useEffect 监听 document click）

### 测试
- `tests/backend/unit/mindmap/test_mindmap_export.py`（新增）
- `tests/frontend/features/workspace/ui/MindmapCanvas.test.jsx`（新增）

## 三、实现思路

### Markdown 导出（递归）
```python
def _payload_to_markdown(node: dict, depth: int = 0) -> str:
    indent = "  " * depth
    line = f"{indent}- **{node['title']}**"
    if summary := node.get("summary"):
        line += f": {summary}"
    children = "\n".join(_payload_to_markdown(c, depth + 1) for c in node.get("children", []))
    return line + ("\n" + children if children else "")
```

### HTML 导出（自包含）
- 生成包含 markmap-view + 当前 JSON 的单文件 HTML
- 用户浏览器打开即可交互，无需后端

### PNG 导出
- 前端 SVG → Canvas 栅格化
- 通过 Blob URL 触发下载
- 选择器限定到 `.mindmap-svg`，避免 lucide 图标污染

### 前端下拉菜单
```jsx
const [open, setOpen] = useState(false);
useEffect(() => {
  const handler = (e) => { if (!ref.current?.contains(e.target)) setOpen(false); };
  document.addEventListener("click", handler);
  return () => document.removeEventListener("click", handler);
}, []);
```

## 四、测试用例

### 后端单元测试
```bash
python -m pytest tests/backend/unit/mindmap/test_mindmap_export.py -v
```

### 前端单元测试
```bash
cd src/frontend && npm test -- MindmapCanvas
```

### 端到端手动验证
- [ ] 生成思维导图 → 点击导出 → 弹出菜单
- [ ] 选择 Markdown → 下载 `.md`，树形结构与原图一致
- [ ] 选择 HTML → 下载 `.html` → 浏览器打开可交互
- [ ] 选择 PNG → 下载图片，无 lucide 图标污染
- [ ] 点击菜单外区域 → 菜单自动关闭
- [ ] 文件名包含视频标题（URL encode 正确）
- [ ] 特殊字符（如中文、emoji）在文件名中正常

## 五、兼容风险

### 向后兼容 
- 仅新增端点，不修改现有路由
- `WorkspaceMindmapView` 仅新增导出按钮，不影响其他视图
- 后端 `render_mindmap_*` 是新增模块，无现有调用方需要迁移

### 文件名 
- 当前导出文件名包含视频标题，已通过 `Content-Disposition` + RFC 5987 编码
- 已修复 Content-Disposition 编码 + 弱断言问题（`1bbb4f7` 测试覆盖）

### 安全 
- 视频标题来自用户输入，文件名需做 path traversal 防护（`..`、`/`）
- 已限制响应 Content-Type，避免 XSS
