### PR TITLE
fix/mindmap-timeout: 思维导图生成 500 (TypeError: timeout kwarg)

### DIFF
--- a/src/backend/shared/llm/litellm_gateway.py
+++ b/src/backend/shared/llm/litellm_gateway.py
@@ -500,6 +500,7 @@ class LiteLLMCompletionGateway:
         response_model: type[StructuredResponseT],
         temperature: float = 0,
         retries: int = 2,
+        timeout: float | None = None,
     ) -> StructuredResponseT:
         """异步结构化输出：要求 LLM 返回符合 Pydantic schema 的对象。
 
@@ -511,6 +512,7 @@ class LiteLLMCompletionGateway:
             response_model: 期望的 Pydantic 模型类。
             temperature: 采样温度，默认 0。
             retries: 最大重试次数（含首次），默认 2 次。
+            timeout: 请求超时秒数，透传给 litellm。None 表示使用 litellm 默认。
 
         Returns:
             通过校验的 Pydantic 模型实例。
@@ -536,6 +538,7 @@ class LiteLLMCompletionGateway:
                         structured_messages,
                         temperature=temperature,
                         response_format=response_format,
+                        timeout=timeout,
                     )
                     _remember_structured_mode(self._structured_mode_cache_key, mode_name)
                     break

--- a/tests/backend/unit/llm/test_litellm_gateway.py
+++ b/tests/backend/unit/llm/test_litellm_gateway.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 import unittest
@@ -355,6 +356,65 @@ class LiteLLMCompletionGatewayStructuredModeTests(unittest.TestCase):
         self.assertIn("不要输出 Markdown", prompt)
         self.assertIn('"SeriesAnswerPayload"', prompt)
         self.assertIn('"citations"', prompt)
+
+    def test_async_acomplete_structured_forwards_timeout_to_acompletion(self) -> None:
+        # T1: explicit timeout reaches the litellm layer.
+        #
+        # Uses SeriesAnswerPayload (already imported at top of file) instead of
+        # MindmapNodePayload: the timeout-forwarding logic is independent of the
+        # response_model type (acomplete_structured is generic over
+        # type[StructuredResponseT] and does not dispatch on it). Keeping
+        # SeriesAnswerPayload avoids pulling video_summary.generation into this
+        # shared-layer test.
+        recorded_timeouts: list[object] = []
+
+        async def recording_acompletion(**kwargs):
+            recorded_timeouts.append(kwargs.get("timeout"))
+            return {"choices": [{"message": {"content": '{"answer": "ok", "citations": [], "used_source_types": []}'}}]}
+
+        gateway = LiteLLMCompletionGateway(
+            provider="openai",
+            model="test-model",
+            base_url="https://example.invalid/v1",
+            api_key="test-key",
+            acompletion_fn=recording_acompletion,
+        )
+
+        result = asyncio.run(
+            gateway.acomplete_structured(
+                [{"role": "user", "content": "生成思维导图"}],
+                response_model=SeriesAnswerPayload,
+                timeout=120,
+            )
+        )
+
+        self.assertEqual(result.answer, "ok")
+        self.assertEqual(recorded_timeouts, [120])
+
+    def test_async_acomplete_structured_default_timeout_is_none(self) -> None:
+        # T2: when timeout is omitted, inner acomplete_text sees None.
+        recorded_timeouts: list[object] = []
+
+        async def recording_acompletion(**kwargs):
+            recorded_timeouts.append(kwargs.get("timeout"))
+            return {"choices": [{"message": {"content": '{"answer": "ok", "citations": [], "used_source_types": []}'}}]}
+
+        gateway = LiteLLMCompletionGateway(
+            provider="openai",
+            model="test-model",
+            base_url="https://example.invalid/v1",
+            api_key="test-key",
+            acompletion_fn=recording_acompletion,
+        )
+
+        asyncio.run(
+            gateway.acomplete_structured(
+                [{"role": "user", "content": "生成思维导图"}],
+                response_model=SeriesAnswerPayload,
+            )
+        )
+
+        self.assertEqual(recorded_timeouts, [None])
 
 
 class CapturingCompletion:


### PR DESCRIPTION
# fix/mindmap-timeout: 思维导图生成 500 (TypeError: timeout kwarg)

> 分支：`fix/mindmap-timeout`
> base：`dev` (8fe9f3b)
> 提交数：2（test → fix，TDD 顺序）

## 一、Bug 场景

### 现象

前端点击"生成思维导图"按钮 → 后端返回 **HTTP 500**：

```
INFO: 127.0.0.1:xxx - "POST /api/videos/bilibili-BV1G29JYQE8b/BV1G29JYQE8b_p6/mindmap/generate HTTP/1.1" 500 Internal Server Error
ERROR: Exception in ASGI application
  File "src/backend/video_summary/infrastructure/litellm_mindmap_generator.py", line 69, in generate
    payload = await self._gateway.acomplete_structured(
  TypeError: LiteLLMCompletionGateway.acomplete_structured() got an unexpected keyword argument 'timeout'
```

UI 表现：用户看到"生成失败"，但实际是服务端代码契约不一致导致的全量失败 —— 任何视频、任何系列的思维导图生成都无法工作。

### 触发路径

1. 前端 `POST /api/videos/{series_id}/{video_id}/mindmap/generate`（无 body，纯触发）
2. 路由 → `container.generate_video_mindmap.run(...)` (Library use case)
3. → `WorkspaceBackedVideoMindmapGenerator.run(...)` (infrastructure adapter)
4. → `ConfiguredMindmapWorkflow.run(...)`
5. → `GenerateMindmap.run(...)` (generation use case)
6. → `LiteLLMMindmapGenerator.generate(...)` (`src/backend/video_summary/infrastructure/litellm_mindmap_generator.py:69`)
7. → `self._gateway.acomplete_structured(..., retries=3, timeout=120)`  **TypeError raised before any LLM call**

### 影响范围

- **完全不可用**：单视频 + 系列两条思维导图生成端点全挂
- **静默无告警**：测试套件全绿、生产日志才暴露
- **首次暴露时机**：feat/mindmap-progress 落地后（2026-06-19）才被用户点出来 —— 进度条打通后，生成流程才真正走通到 LLM 调用点

## 二、为什么没测试出来

> 这是这个 bug 最值得复盘的部分。**本地 CI 全绿、生产即坏** —— 经典测试盲区。

### 1. 单元测试只覆盖了"未被破坏的路径"

`LiteLLMCompletionGateway` 已有 17 个单元测试，**全部调用 `acomplete_structured` 但全部不传 `timeout`**：

```python
# tests/backend/unit/llm/test_litellm_gateway.py:191 (before fix)
result = gateway.complete_structured(
    [{"role": "user", "content": "回答问题"}],
    response_model=SeriesAnswerPayload,
    # 没有 timeout=
)
```

原因是测试只用 sync 路径 `complete_structured` 验证 schema-mode 缓存逻辑（json_schema → json_object → prompt fallback），从不进入 `retries + timeout` 的真实使用场景。`timeout=` 是后续 `feat/mindmap-progress` 加上 progress tracker 时一起引入的新调用，但**没有补对应测试**。

### 2. Integration 测试用 FakeGateway mock 兜底

`tests/backend/integration/llm/test_litellm_summarizer.py:153` 的 `FakeGateway.acomplete_structured` mock 签名只声明了 `messages, response_model, temperature, retries` —— **没有 `timeout` 参数**。因为它从未被 caller 触发过 timeout 路径（summarizer 也不传 timeout），所以这个签名"看起来对"。

更糟的是：mock 的实现细节 (`return SummaryPayload(...)`) 让 `acomplete_structured` 在测试中**总是返回成功**。即使真实 gateway 缺 `timeout` 参数，测试 mock 也不会抛 `TypeError`，因为 mock 自身就是接口实现。

### 3. 调用方 (mindmap generator) 没有针对 gateway 的契约测试

`tests/backend/unit/llm/test_litellm_mindmap_generator.py` 不存在（也没必要 —— 它是 LLM 适配器，正确行为是发请求而非返回数据）。但**没有任何地方测试 "调用方传入的 kwargs 都能被 gateway 接受"** 这种契约。

### 4. 静态类型检查缺位

`timeout: float | None = None` 这类 kwarg-only 参数不会被 mypy 的严格模式捕捉（因为 `**kwargs` 转发链的运行时校验在 Pydantic/litellm 边界）。`from __future__ import annotations` + Python 3.11 的 PEP 604 联合类型让接口签名看起来"OK"，但实际调用时由解释器运行时 reject。

### 5. 没有 E2E 测试覆盖 mindmap 生成

仓库没有 end-to-end 测试套件能"启动 FastAPI + 真实调用 LLM + 验证 mindmap.json 落盘"。Live smoke 一直靠人工（用户点击）兜底。

### 6. 复盘结论

| 测试层 | 应捕获但未捕获 | 原因 |
|---|---|---|
| 单元（gateway） | ✗ | 已有测试只走 schema-mode 缓存路径，不传 timeout |
| 单元（mindmap generator） | ✗ | 用 mock gateway，mock 接口不严格 |
| Integration | ✗ | `FakeGateway` mock 同样不严格 |
| E2E | ✗ | 不存在 |
| 静态检查 | ✗ | Python kwargs 是运行时检查 |

**根本原因**：`acomplete_structured` 公共 API 表面扩张时（`retries` 后追加 `timeout`），没有对应的契约测试守住"调用方传的 kwargs 必须全被接受"这条不变量。

## 三、修复方法

### 方案对比

| 方案 | 改动量 | 后果 | 评价 |
|---|---|---|---|
| A. Gateway 加 `timeout` kwarg + 透传 | 1 文件 3 行 | 公共 API 扩张；调用方继续用 120s/300s 显式预算 |  **采用**：对称 `acomplete_text`（已收 `timeout`）、向后兼容（默认 `None`）、保留 caller 意图 |
| B. Caller 删除 `timeout=` | 2 文件 -2 行 | 公共 API 不变；但系列 300s 显式预算丢失，可能撞 litellm 默认 60-90s 超时 |  拒绝：删掉 caller 已知正确的配置 |
| C. 同步 `complete_structured` 也加 `timeout` | 1 文件 1 行 | 顺手；当前 2 个 sync caller 都不需要 |  YAGNI：等有人用再加 |

### 实际改动（3 行核心代码）

`src/backend/shared/llm/litellm_gateway.py` 三处增补：

```python
# ① acomplete_structured 签名 (line 503)
async def acomplete_structured(
    self,
    messages: Sequence[dict[str, Any]],
    *,
    response_model: type[StructuredResponseT],
    temperature: float = 0,
    retries: int = 2,
    timeout: float | None = None,        # ← 新增
) -> StructuredResponseT:

# ② docstring Args 块 (line 515)
            timeout: 请求超时秒数，透传给 litellm。None 表示使用 litellm 默认。

# ③ 内部 acomplete_text 调用 (line 541)
                    last_raw_text = await self.acomplete_text(
                        structured_messages,
                        temperature=temperature,
                        response_format=response_format,
                        timeout=timeout,             # ← 透传
                    )
```

### 为什么不在 caller 改

`timeout=120` (单视频) 和 `timeout=300` (系列) 是 caller 显式选的预算，删掉是回归。Gateway 修 1 处，5 个 caller 全部受益，是更小的 blast radius。

### 为什么 sync `complete_structured` 不动

当前 sync caller (`chat_gateway.py:125`, `litellm_knowledge_card_generator.py:83`) 都不传 timeout。按 YAGNI 暂不动；如果未来有人需要 sync 超时，照搬 async 的 pattern 即可（5 行同形改动）。

### 不动的部分（明确 out-of-scope）

- `acomplete_text`（已收 `timeout`，不动）
- `astream_text`（**已知限制**：streaming fallback 路径不传播 `timeout`，单独 enhancement 处理）
- mindmap generator 不引入 `cancellable_await`（属于另一个 feature）

## 四、测试

### TDD 顺序

1. **红** (`42fde48`): 加 T1 + T2，验证 T1 失败（`TypeError`）+ T2 通过（基线）
2. **绿** (`050679c`): 改 gateway 签名 + 透传，验证 T1 + T2 全过 + 17 已有测试无回归

### 新增测试用例

`tests/backend/unit/llm/test_litellm_gateway.py`（+60 行，0 删除）：

| ID | 名称 | 验证 |
|---|---|---|
| **T1** | `test_async_acomplete_structured_forwards_timeout_to_acompletion` | 显式 `timeout=120` 透传到 litellm → `recorded_timeouts == [120]` |
| **T2** | `test_async_acomplete_structured_default_timeout_is_none` | 不传 `timeout` → 内层 `acomplete_text` 收到 `None`（向后兼容基线）|

> **T3（曾考虑）已删除**：原本计划加 `test_sync_complete_structured_rejects_timeout_kwarg` 守 sync 版本不收 timeout，但这是 tautological —— Python 的 kwarg binding 本身就会 reject，测试断言 `TypeError` 不会因为 gateway 改动而失败/通过。已从 plan 中删除。

### 完整测试结果

| 测试范围 | 结果 |
|---|---|
| `tests/backend/unit/llm/test_litellm_gateway.py` | **19 passed** (17 已有 + T1 + T2) |
| `tests/backend/integration/llm` | **26 passed** |
| `tests/backend/unit`（排除 pre-existing `test_bili_downloader_script.py` 的 `ModuleNotFoundError`，与本 fix 无关）| **133 passed** |
| `lint-imports` (import-linter) | **10 contracts kept, 0 broken** |
| Live `POST /api/videos/bilibili-BV1G29JYQE8b/BV1G29JYQE8b_p6/mindmap/generate` | **HTTP 200** + 完整 `MindmapNodePayload` JSON |
| `grep -c "unexpected keyword argument 'timeout'" runtime/dev-server.log` | **0** |

### 复测脚本

```bash
# 单元
runtime/python.exe -m pytest tests/backend/unit/llm/test_litellm_gateway.py -v
runtime/python.exe -m pytest tests/backend/integration/llm -v
runtime/python.exe -m pytest tests/backend/unit --ignore=tests/backend/unit/bilibili/test_bili_downloader_script.py

# 边界
lint-imports

# Live smoke
PYTHONPATH=src runtime/python.exe -m uvicorn backend.api.app:app --host 127.0.0.1 --port 8001 --reload &
sleep 5
curl -X POST "http://127.0.0.1:8001/api/videos/bilibili-BV1G29JYQE8b/BV1G29JYQE8b_p6/mindmap/generate" --max-time 600
grep -c "unexpected keyword argument 'timeout'" runtime/dev-server.log
```

## 五、兼容性

### 向后兼容 

- **类型注解**：`timeout: float | None = None`，默认 `None` → 不传 kwarg 的 5 个 caller 行为完全不变
- **签名位置**：kwarg-only（`*` 之后），不破坏任何位置参数调用方
- **API 对称性**：与已存在的 `acomplete_text(messages, ..., timeout=...)` (line 168) 完全对齐，调用方心智模型一致
- **测试覆盖**：T2 显式断言"不传 timeout → 内层看到 None"，锁住向后兼容基线

### 影响面

| 范围 | 影响 |
|---|---|
| `LiteLLMMindmapGenerator.generate` (单视频) | 从 500 → 200，timeout=120 实际生效 |
| `LiteLLMSeriesMindmapGenerator.generate` (系列) | 同上，timeout=300 实际生效 |
| `LiteLLMSummarizer` × 2 + `LiteLLMTranscriptEnhancer` × 1 | 无影响（不传 timeout）|
| Sync `complete_structured` 2 个 caller | 无影响（未触碰）|
| Public API 表面 | +1 个可选 kwarg，non-breaking |

### 已知限制（不在本 PR 范围）

1. **`astream_text` 不接受 `timeout`**：`acomplete_text` 在返回空 content 时 fallback 到 `astream_text`（line 215-222），fallback 路径不受 timeout 保护。本次修复不动这层（mindmap prompt 在生产环境下不会触发 empty content 的 fallback）；后续若要补，按相同 pattern 扩 `astream_text` + `_build_completion_request` 即可。
2. **Sync `complete_structured` 未加 `timeout`**：YAGNI，等有 caller 需要再说。
3. **Mindmap generator 未接 `cancellable_await`**：summarizer / transcript_enhancer 走 cancellation 包装，mindmap 暂未接入 —— 属于 feature 而非 bug fix。

### Wall-clock 上界

- **成功路径**：`retries=3 × 1 mode × 120s = ≤ 480s`（timeout=120）
- **理论最坏**：`4 attempts × 3 modes × 120s = ≤ 1440s`（所有 response_format 模式被 reject + 所有 validation 失败）
- 系列 worst case（timeout=300）：`≤ 3600s`
- 没有总时间硬上限，由 caller 显式选择；可接受。

## 六、Commit 列表

```
050679c fix(llm-gateway): plumb timeout kwarg through acomplete_structured
42fde48 test(llm-gateway): add T1/T2 tests for acomplete_structured timeout forwarding
```

TDD 顺序：先红测试（commit #1）后修复（commit #2），便于回滚和 review。

## 七、复盘要点（致 reviewer）

1. **测试覆盖盲区**：`acomplete_structured` 公共 API 扩张时（加 `timeout`）没补对应测试 —— 已有 17 个测试都只走 schema-mode 缓存路径，**没人测 timeout 透传**。建议未来给 `LiteLLMCompletionGateway` 加一个 property-based 测试或契约测试，断言"所有 caller 传的 kwargs 都能被 gateway 接受"。

2. **Mock 签名松散**：`tests/backend/integration/llm/test_litellm_summarizer.py:153` 的 `FakeGateway.acomplete_structured` mock 签名与真实 gateway 不严格对齐（少 `timeout` 等参数）。建议 mock 用 `**kwargs` 透传或跟真实签名严格同步，否则会掩盖契约漂移。

3. **T3 教训**：写过 `test_sync_complete_structured_rejects_timeout_kwarg` 后 review 时被识别为 tautological（Python kwarg binding 本身就会 reject）。教训：写测试前先想"如果生产代码完全没动，这个测试会通过吗？"——答 yes 就是 tautological，删除。

4. **过程教训**：本次 bug 暴露路径值得记一笔 —— 路由表 stale (旧 server 跑旧代码) → 用户看到 404 → 重启 dev server → 路由表补全 → 真实 500 暴露。下次类似情况先 `curl /openapi.json` 对比注册路由 vs 源码头，能快速分辨"路由没注册"vs"路由注册了但内部错"。

## 八、附件
- 复现 curl：
  ```bash
  curl -X POST "http://127.0.0.1:8001/api/videos/bilibili-BV1G29JYQE8b/BV1G29JYQE8b_p6/mindmap/generate" --max-time 600
  ```
