### PR TITLE
feat/library-core-problem-preview: 库面板视频卡片显示 Core Problem 

### DIFF
--- a/src/backend/api/responses.py
+++ b/src/backend/api/responses.py
@@ -43,6 +43,7 @@ class VideoCardResponse(BaseModel):
     source_type: str
     processed: bool
     status: str
+    core_problem: str = ""
     is_linked: bool = False
     bilibili_bvid: str = ""
     bilibili_page: int = 0
@@ -66,6 +67,7 @@ class VideoCardResponse(BaseModel):
             source_type=video.source_type,
             processed=video.processed,
             status=video.status,
+            core_problem=video.core_problem,
             is_linked=video.is_linked,
             bilibili_bvid=video.bilibili_bvid,
             bilibili_page=video.bilibili_page,

--- a/src/backend/video_summary/infrastructure/filesystem_video_workspace.py
+++ b/src/backend/video_summary/infrastructure/filesystem_video_workspace.py
@@ -782,6 +782,26 @@ class FileSystemVideoWorkspace:
             status="ready" if processed else "pending",
         )
 
+    def _read_core_problem(self, series_id: str, video_id: str) -> str:
+        """从本地 summary.json 提取 core_problem 字段。
+
+        返回空串的所有路径都视为"无 core_problem",不抛异常:
+            - summary.json 不存在
+            - summary.json 读取失败 (OSError)
+            - summary.json 不是合法 JSON (ValueError)
+            - core_problem 字段缺失
+            - core_problem 不是字符串
+        """
+        summary_path = self._workspace_dir / series_id / video_id / "summary.json"
+        if not summary_path.is_file():
+            return ""
+        try:
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return ""
+        value = payload.get("core_problem", "")
+        return value.strip() if isinstance(value, str) else ""
+
     def _copy_video_streams(self, *, series_dir: Path, files: list[tuple[str, object]]) -> list[Path]:
         """把 `[(filename, stream), ...]` 复制到目标系列目录中。
 

--- a/src/backend/video_summary/infrastructure/filesystem_video_workspace.py
+++ b/src/backend/video_summary/infrastructure/filesystem_video_workspace.py
@@ -733,14 +733,17 @@ class FileSystemVideoWorkspace:
             consumed_video_ids.add(video_id)
             local_file = local_paths_by_stem.get(video_id)
             if local_file is not None:
+                summary_path = self._workspace_dir / series_id / video_id / "summary.json"
+                has_summary = summary_path.is_file()
                 cards.append(
                     LibraryVideoCardDTO(
                         id=video_id,
                         title=str(item.get("title", video_id)).strip() or video_id,
                         source_name=local_file.name,
                         source_type=_source_type_for_path(local_file),
-                        processed=(self._workspace_dir / series_id / video_id / "summary.json").exists(),
-                        status="ready" if (self._workspace_dir / series_id / video_id / "summary.json").exists() else "pending",
+                        processed=has_summary,
+                        status="ready" if has_summary else "pending",
+                        core_problem=self._read_core_problem(series_id, video_id),
                         is_linked=False,
                         bilibili_bvid=bvid,
                         bilibili_page=page,
@@ -757,6 +760,7 @@ class FileSystemVideoWorkspace:
                     source_type="video",
                     processed=False,
                     status="linked",
+                    core_problem="",
                     is_linked=True,
                     bilibili_bvid=bvid,
                     bilibili_page=page,
@@ -772,14 +776,16 @@ class FileSystemVideoWorkspace:
 
     def _build_local_video_card(self, series_id: str, video_path: Path) -> LibraryVideoCardDTO:
         """按媒体文件路径构造本地视频卡片，状态以 `summary.json` 是否存在为判据。"""
-        processed = (self._workspace_dir / series_id / video_path.stem / "summary.json").exists()
+        summary_path = self._workspace_dir / series_id / video_path.stem / "summary.json"
+        has_summary = summary_path.is_file()
         return LibraryVideoCardDTO(
             id=video_path.stem,
             title=video_path.stem,
             source_name=video_path.name,
             source_type=_source_type_for_path(video_path),
-            processed=processed,
-            status="ready" if processed else "pending",
+            processed=has_summary,
+            status="ready" if has_summary else "pending",
+            core_problem=self._read_core_problem(series_id, video_path.stem),
         )
 
     def _read_core_problem(self, series_id: str, video_id: str) -> str:

--- a/src/backend/video_summary/library/models.py
+++ b/src/backend/video_summary/library/models.py
@@ -64,6 +64,7 @@ class LibraryVideoCardDTO:
         source_name: 源文件展示名（本地）或站点名（外部链接）。
         processed: 是否已生成至少一份制品（总结/转写/思维导图等）。
         status: 处理状态文本（如 "pending"/"ready"/"failed"），由用例层定义。
+        core_problem: 视频总结中的核心问题摘要，空字符串表示未生成或无内容。
         source_type: 源类型，"video" 表示本地视频文件。
         is_linked: 是否来自外部链接（未实际下载到本地）。
         bilibili_bvid: Bilibili BV 号；非 B 站来源时为空字符串。
@@ -77,6 +78,7 @@ class LibraryVideoCardDTO:
     source_name: str
     processed: bool
     status: str
+    core_problem: str = ""
     source_type: str = "video"
     is_linked: bool = False
     bilibili_bvid: str = ""

--- a/src/frontend/src/features/workspace/model/workspaceViewModel.js
+++ b/src/frontend/src/features/workspace/model/workspaceViewModel.js
@@ -39,6 +39,7 @@ function asVideoCard(value, label) {
     sourceType: record.source_type === "audio" ? "audio" : "video",
     processed: Boolean(record.processed),
     status: asString(record.status, `${label}.status`),
+    coreProblem: asOptionalString(record.core_problem),
     isLinked: Boolean(record.is_linked),
     bilibiliBvid: typeof record.bilibili_bvid === "string" ? record.bilibili_bvid : "",
     bilibiliPage: typeof record.bilibili_page === "number" ? record.bilibili_page : 0,

--- a/src/frontend/src/features/workspace/ui/WorkspaceLibraryPanel.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceLibraryPanel.jsx
@@ -405,7 +405,7 @@ export function WorkspaceLibraryPanel({
       return videos;
     }
     return videos.filter((video) => {
-      const haystacks = [video.title, video.sourceName, video.sourceUrl]
+      const haystacks = [video.title, video.sourceName, video.sourceUrl, video.coreProblem]
         .filter((value) => typeof value === "string")
         .map((value) => value.toLowerCase());
       return haystacks.some((value) => value.includes(normalizedFilter));
@@ -554,6 +554,14 @@ export function WorkspaceLibraryPanel({
                 <strong className={`text-sm font-semibold line-clamp-2 ${isActive ? "text-stone-900 dark:text-stone-100" : "text-stone-800 dark:text-stone-100"}`}>
                   {video.title}
                 </strong>
+                {video.coreProblem ? (
+                  <span
+                    className="text-xs text-stone-600 dark:text-stone-300 line-clamp-2 leading-snug whitespace-pre-line"
+                    title={video.coreProblem}
+                  >
+                    {video.coreProblem}
+                  </span>
+                ) : null}
                 <span className="text-xs text-stone-500 dark:text-stone-400 truncate">
                   {video.isLinked || video.status === "linked" ? video.sourceUrl || video.sourceName : video.sourceName}
                 </span>

--- a/tests/backend/unit/library/test_library_models.py
+++ b/tests/backend/unit/library/test_library_models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import FrozenInstanceError
+
+from backend.video_summary.library.models import LibraryVideoCardDTO
+
+
+class LibraryVideoCardDTOTest(unittest.TestCase):
+    def test_default_core_problem_is_empty_string(self) -> None:
+        card = LibraryVideoCardDTO(
+            id="v1", title="V1", source_name="v1.mp4",
+            processed=False, status="pending",
+        )
+        self.assertEqual(card.core_problem, "")
+
+    def test_explicit_core_problem_is_preserved(self) -> None:
+        card = LibraryVideoCardDTO(
+            id="v1", title="V1", source_name="v1.mp4",
+            processed=True, status="ready",
+            core_problem="如何用三步拆解复杂问题",
+        )
+        self.assertEqual(card.core_problem, "如何用三步拆解复杂问题")
+
+    def test_dto_remains_frozen_after_field_added(self) -> None:
+        card = LibraryVideoCardDTO(
+            id="v1", title="V1", source_name="v1.mp4",
+            processed=False, status="pending",
+        )
+        with self.assertRaises(FrozenInstanceError):
+            card.core_problem = "不应该能改"  # type: ignore[misc]

--- a/tests/backend/unit/library/test_workspace_listing.py
+++ b/tests/backend/unit/library/test_workspace_listing.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from backend.video_summary.infrastructure.filesystem_video_workspace import (
+    FileSystemVideoWorkspace,
+)
+
+
+def _make_workspace(root: Path) -> FileSystemVideoWorkspace:
+    """构造最小 workspace 目录: <root>/workspace 与 <root>/videos。"""
+    (root / "workspace").mkdir()
+    (root / "videos").mkdir()
+    return FileSystemVideoWorkspace(root)
+
+
+class ReadCoreProblemTests(unittest.TestCase):
+    """_read_core_problem 4 种降级路径 + 正常路径(B2 验收)。"""
+
+    def test_returns_empty_when_summary_file_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = _make_workspace(Path(tmp))
+            self.assertEqual(ws._read_core_problem("s1", "v1"), "")
+
+    def test_returns_empty_when_summary_malformed_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = _make_workspace(Path(tmp))
+            summary_dir = ws._workspace_dir / "s1" / "v1"
+            summary_dir.mkdir(parents=True)
+            (summary_dir / "summary.json").write_text("{ this is not json", encoding="utf-8")
+            self.assertEqual(ws._read_core_problem("s1", "v1"), "")
+
+    def test_returns_empty_when_core_problem_not_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = _make_workspace(Path(tmp))
+            summary_dir = ws._workspace_dir / "s1" / "v1"
+            summary_dir.mkdir(parents=True)
+            (summary_dir / "summary.json").write_text(
+                json.dumps({"core_problem": 42}), encoding="utf-8"
+            )
+            self.assertEqual(ws._read_core_problem("s1", "v1"), "")
+
+    def test_returns_empty_when_core_problem_field_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = _make_workspace(Path(tmp))
+            summary_dir = ws._workspace_dir / "s1" / "v1"
+            summary_dir.mkdir(parents=True)
+            (summary_dir / "summary.json").write_text(
+                json.dumps({"title": "other"}), encoding="utf-8"
+            )
+            self.assertEqual(ws._read_core_problem("s1", "v1"), "")
+
+    def test_returns_stripped_string_when_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = _make_workspace(Path(tmp))
+            summary_dir = ws._workspace_dir / "s1" / "v1"
+            summary_dir.mkdir(parents=True)
+            (summary_dir / "summary.json").write_text(
+                json.dumps({"core_problem": "  如何拆解复杂问题  \n"}),
+                encoding="utf-8",
+            )
+            self.assertEqual(ws._read_core_problem("s1", "v1"), "如何拆解复杂问题")

--- a/tests/backend/unit/library/test_workspace_listing.py
+++ b/tests/backend/unit/library/test_workspace_listing.py
@@ -63,3 +63,93 @@ class ReadCoreProblemTests(unittest.TestCase):
                 encoding="utf-8",
             )
             self.assertEqual(ws._read_core_problem("s1", "v1"), "如何拆解复杂问题")
+
+
+class ListSeriesCoreProblemTests(unittest.TestCase):
+    """list_series 端到端返回 DTO 时填入 core_problem 字段。"""
+
+    def _seed_workspace(self, root: Path, series_id: str, video_id: str, *, with_summary: bool, core_problem: str = "") -> None:
+        """seed 一个最小本地 series + video,可选地写 summary.json。"""
+        (root / "videos" / series_id).mkdir(parents=True)
+        (root / "videos" / series_id / f"{video_id}.mp4").write_bytes(b"\x00")
+        if with_summary:
+            summary_dir = root / "workspace" / series_id / video_id
+            summary_dir.mkdir(parents=True)
+            (summary_dir / "summary.json").write_text(
+                json.dumps({"core_problem": core_problem}), encoding="utf-8"
+            )
+
+    def test_pure_local_video_includes_core_problem(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._seed_workspace(root, "s1", "v1", with_summary=True, core_problem="如何 X")
+            ws = FileSystemVideoWorkspace(root)
+            series_list = ws.list_series()
+            cards = [c for s in series_list for c in s.videos if c.id == "v1"]
+            self.assertEqual(len(cards), 1)
+            self.assertEqual(cards[0].core_problem, "如何 X")
+
+    def test_pure_local_video_omits_core_problem_when_no_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._seed_workspace(root, "s1", "v1", with_summary=False)
+            ws = FileSystemVideoWorkspace(root)
+            series_list = ws.list_series()
+            cards = [c for s in series_list for c in s.videos if c.id == "v1"]
+            self.assertEqual(len(cards), 1)
+            self.assertEqual(cards[0].core_problem, "")
+
+    def test_linked_without_local_file_has_empty_core_problem(self) -> None:
+        """linked 系列,本地无视频文件,core_problem 必为空。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "workspace" / "s_linked").mkdir(parents=True)
+            (root / "workspace" / "s_linked" / "linked_series.json").write_text(
+                json.dumps({
+                    "title": "Linked Series",
+                    "source_url": "https://example.com",
+                    "videos": [
+                        {"bvid": "BV_LINKED", "page": 1, "title": "Linked V1",
+                         "source_url": "https://example.com/v1", "provider": "bilibili"}
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            ws = FileSystemVideoWorkspace(root)
+            series_list = ws.list_series()
+            cards = [c for s in series_list for c in s.videos if c.id == "BV_LINKED"]
+            self.assertEqual(len(cards), 1)
+            self.assertEqual(cards[0].core_problem, "")
+            self.assertTrue(cards[0].is_linked)
+
+    def test_linked_with_local_file_pulls_core_problem_from_local_summary(self) -> None:
+        """linked 系列,本地已下载且有 summary.json,应能拿到 core_problem。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "workspace" / "s_linked").mkdir(parents=True)
+            (root / "workspace" / "s_linked" / "linked_series.json").write_text(
+                json.dumps({
+                    "title": "Linked Series",
+                    "source_url": "https://example.com",
+                    "videos": [
+                        {"bvid": "BV_DOWNLOADED", "page": 1, "title": "Downloaded V",
+                         "source_url": "https://example.com/v", "provider": "bilibili"}
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            # 本地视频文件存在
+            (root / "videos" / "s_linked").mkdir(parents=True)
+            (root / "videos" / "s_linked" / "BV_DOWNLOADED.mp4").write_bytes(b"\x00")
+            # 本地 summary.json 存在
+            summary_dir = root / "workspace" / "s_linked" / "BV_DOWNLOADED"
+            summary_dir.mkdir(parents=True)
+            (summary_dir / "summary.json").write_text(
+                json.dumps({"core_problem": "已下载并已总结"}), encoding="utf-8"
+            )
+            ws = FileSystemVideoWorkspace(root)
+            series_list = ws.list_series()
+            cards = [c for s in series_list for c in s.videos if c.id == "BV_DOWNLOADED"]
+            self.assertEqual(len(cards), 1)
+            self.assertEqual(cards[0].core_problem, "已下载并已总结")
+            self.assertFalse(cards[0].is_linked)

--- a/tests/frontend/features/workspace/model/workspaceViewModel.test.jsx
+++ b/tests/frontend/features/workspace/model/workspaceViewModel.test.jsx
@@ -64,4 +64,84 @@ describe("toWorkspaceLibrary", () => {
 
     expect(library.series[0].videos[0].sourceType).toBe("audio");
   });
+
+  it("maps core_problem to coreProblem when present", () => {
+    const library = toWorkspaceLibrary({
+      workspace: { id: "ws", title: "Workspace" },
+      series: [
+        {
+          id: "s1",
+          title: "S1",
+          is_linked: false,
+          source_url: "",
+          videos: [
+            {
+              id: "v1",
+              title: "V1",
+              source_name: "v1.mp4",
+              processed: true,
+              status: "ready",
+              core_problem: "如何用三步拆解复杂问题",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(library.series[0].videos[0]).toMatchObject({
+      coreProblem: "如何用三步拆解复杂问题",
+    });
+  });
+
+  it("returns empty coreProblem when core_problem field is missing", () => {
+    const library = toWorkspaceLibrary({
+      workspace: { id: "ws", title: "Workspace" },
+      series: [
+        {
+          id: "s1",
+          title: "S1",
+          is_linked: false,
+          source_url: "",
+          videos: [
+            {
+              id: "v1",
+              title: "V1",
+              source_name: "v1.mp4",
+              processed: false,
+              status: "pending",
+              // core_problem 故意不传
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(library.series[0].videos[0].coreProblem).toBe("");
+  });
+
+  it("returns empty coreProblem when core_problem is not a string", () => {
+    const library = toWorkspaceLibrary({
+      workspace: { id: "ws", title: "Workspace" },
+      series: [
+        {
+          id: "s1",
+          title: "S1",
+          is_linked: false,
+          source_url: "",
+          videos: [
+            {
+              id: "v1",
+              title: "V1",
+              source_name: "v1.mp4",
+              processed: true,
+              status: "ready",
+              core_problem: 42,  // 故意传错类型
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(library.series[0].videos[0].coreProblem).toBe("");
+  });
 });

--- a/tests/frontend/features/workspace/ui/WorkspaceLibraryPanel.test.jsx
+++ b/tests/frontend/features/workspace/ui/WorkspaceLibraryPanel.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { WorkspaceLibraryPanel } from "@src/features/workspace/ui/WorkspaceLibraryPanel";
@@ -53,5 +53,95 @@ describe("WorkspaceLibraryPanel", () => {
     const sourceLink = screen.getByTitle("在 Bilibili 中查看");
 
     expect(sourceLink).toHaveAttribute("href", linkedDownloadedVideo.sourceUrl);
+  });
+
+  function renderPanelWithVideo(video) {
+    return render(
+      <WorkspaceLibraryPanel
+        activeSeries={{
+          id: "s1",
+          title: "S1",
+          videos: [video],
+        }}
+        selectedContextType="video"
+        selectedVideo={video}
+        isGeneratingSelectedVideo={false}
+        isGeneratingSeries={false}
+        seriesGenerationQueue={null}
+        currentAsrModel={{ id: "large-v3-turbo", label: "large-v3-turbo", downloaded: true }}
+        ragModels={[]}
+        onEnterLibraryHome={vi.fn()}
+        onSelectSeriesContext={vi.fn()}
+        onSelectVideo={vi.fn()}
+        onGenerateVideo={vi.fn()}
+        onGenerateSeries={vi.fn()}
+        onCancelGeneration={vi.fn()}
+        onDownloadVideo={vi.fn()}
+        onAddPlaygroundVideo={vi.fn()}
+        onAddSeriesVideo={vi.fn()}
+        onDeleteSeries={vi.fn()}
+        onRequestDeleteCurrentVideo={vi.fn()}
+        onRequestDeleteSeries={vi.fn()}
+        downloadProgress={null}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+  }
+
+  it("renders core_problem under title when present", () => {
+    renderPanelWithVideo({
+      ...linkedDownloadedVideo,
+      coreProblem: "如何用三步拆解复杂问题",
+    });
+
+    expect(screen.getByText("如何用三步拆解复杂问题")).toBeInTheDocument();
+  });
+
+  it("omits core_problem display when coreProblem is empty", () => {
+    renderPanelWithVideo({
+      ...linkedDownloadedVideo,
+      coreProblem: "",
+    });
+
+    // 找到 title 所在的 strong 元素的父容器,确认其下没有非空 line-clamp-2 span
+    const titleNodes = screen.getAllByText(linkedDownloadedVideo.title);
+    const titleStrong = titleNodes.find((node) => node.tagName.toLowerCase() === "strong");
+    expect(titleStrong).toBeTruthy();
+    const card = titleStrong.closest("button");
+    const coreProblemSpan = card?.querySelector("span.line-clamp-2");
+    expect(coreProblemSpan === null || coreProblemSpan.textContent === "").toBe(true);
+  });
+
+  it("matches videos by core_problem in search filter", () => {
+    renderPanelWithVideo({
+      ...linkedDownloadedVideo,
+      coreProblem: "拆解复杂问题",
+    });
+
+    const searchInput = screen.getByPlaceholderText(/筛选当前系列内容/);
+    fireEvent.change(searchInput, { target: { value: "拆解" } });
+
+    // 卡片应仍然可见
+    expect(screen.getByText("拆解复杂问题")).toBeInTheDocument();
+  });
+
+  it("renders embedded newlines in core_problem with whitespace-pre-line", () => {
+    renderPanelWithVideo({
+      ...linkedDownloadedVideo,
+      coreProblem: "第一行\n第二行",
+    });
+
+    // 使用 querySelectorAll 找到含换行符的 span (title= attribute 也是证据)
+    const card = screen.getAllByText(linkedDownloadedVideo.title)
+      .find((node) => node.tagName.toLowerCase() === "strong")
+      ?.closest("button");
+    expect(card).toBeTruthy();
+    const spans = Array.from(card.querySelectorAll("span"));
+    const span = spans.find((node) => node.textContent?.includes("第一行"));
+    expect(span).toBeTruthy();
+    expect(span?.textContent).toContain("第一行");
+    expect(span?.textContent).toContain("第二行");
+    expect(span?.className).toContain("whitespace-pre-line");
+    expect(span?.className).toContain("line-clamp-2");
   });
 });


### PR DESCRIPTION
# feat/library-core-problem-preview: 库面板视频卡片显示 Core Problem 

## 一、变更背景

当前 `WorkspaceLibraryPanel` 左侧视频列表只展示视频标题与文件名,用户在选择视频前需要点开阅读面板才能看到这条视频"在讲什么"。对于系列下几十个视频的场景,逐个点开判断成本高。

`SummaryPayload.core_problem` 字段(后端已生成)正好是 LLM 总结出的"核心问题",是天然的快速识别标签。本次在列表卡片中复用此字段。

## 二、改动范围

6 个 commit,5 个源文件 + 2 个新测试文件 + 2 个测试扩展:

### 1. DTO 加字段
- `src/backend/video_summary/library/models.py:54-87` — `LibraryVideoCardDTO` 加 `core_problem: str = ""` 字段(放在 `status` 与 `source_type` 之间),docstring 同步

### 2. helper:从 summary.json 提取 core_problem
- `src/backend/video_summary/infrastructure/filesystem_video_workspace.py:808-828` — 新增 `_read_core_problem(series_id, video_id) -> str` 私有方法
- 4 种降级路径全部返 `""`(B2 验收):文件不存在 / OSError / ValueError / 字段缺失或非字符串

### 3. 3 个本地视频构造点接入 helper
- `filesystem_video_workspace.py:760`(linked-with-local-file)— 接入 helper,**顺手清理原 line 765-766 重复的 `Path.exists()` 调用**为单一 `has_summary` 局部变量
- `filesystem_video_workspace.py:776`(linked-without-local-file)— 显式 `core_problem=""`
- `filesystem_video_workspace.py:799`(`_build_local_video_card` 纯本地)— 接入 helper + 抽 `has_summary` 局部
- Linked / Chaoxing 视频路径(`linked_videos.py:213` / `chaoxing.py:298`)v1 不填充(linked 视频本身不进本地 summary 流程,字段恒为空,与未生成视觉一致)

### 4. viewModel 映射
- `src/frontend/src/features/workspace/model/workspaceViewModel.js:42` — `asVideoCard` 加 `coreProblem: asOptionalString(record.core_problem)`
- **关键**:`asOptionalString` 而非 `asString`(后者在空值时抛错,会破坏未生成视频的列表渲染)

### 5. 列表渲染 + 搜索
- `src/frontend/src/features/workspace/ui/WorkspaceLibraryPanel.jsx:557-563` — 在 title 与 source_name 之间插入 core_problem `<span>`,样式 `line-clamp-2 whitespace-pre-line leading-snug` + `title` 属性(鼠标悬停看完整文本)
- `WorkspaceLibraryPanel.jsx:408` — 搜索 haystack 加入 `video.coreProblem`

### 6.  Bug 修复:API 层响应模型漏字段( **真让我好找啊**)
- 单独测能返回12个字段，怎么e2e就只有11个字段
- `src/backend/api/responses.py:46-74` — `VideoCardResponse`(API 层 Pydantic 模型)和 `from_model` **漏了** `core_problem`,导致即使 domain DTO 已填字段,FastAPI 响应仍会过滤掉
- 这是实施时遗漏的"二次映射层"问题(domain DTO → API response DTO 需同步)。已在 commit 中标注。

## 三、实现思路

### 后端:helper + 4 降级路径集中处理

把读 `summary.json` 抽成一个 `_read_core_problem` 实例方法而不是在每个构造点重复 IO。原因:
- 降级逻辑(文件不存在 / 解析失败 / 字段缺失)集中在一处,易测试、易维护
- 性能:`Path.is_file()` + 失败时立刻返 `""`,避免大部分视频(已生成)的多余 IO

### 前端:空值不渲染 + 视觉与已有控件对齐

```
┌─────────────────────────────────────┐
│ [已生成概况]                  [📹]   │  ← badge + icon(已有)
│ 1.1 计算机系统简介 课程简介        │  ← title(已有,line-clamp-2)
│ 数据库系统面临的主要问题:数据库系统  │  ← core_problem(新,line-clamp-2 + ws-pre-line)
│ BV1t4411e7LH.mp4                  │  ← source_name(已有)
└─────────────────────────────────────┘
```

<img width="410" height="406" alt="image" src="https://github.com/user-attachments/assets/76cc37d9-700a-4253-bbeb-0ef4c02a0a25" />

`line-clamp-2` 与 title 视觉层级一致,`whitespace-pre-line` 保留 LLM 输出的 `\n`,`title` 属性提供 hover tooltip。

### 关于 B2:helper 4 降级路径的测试策略

`helper` 是同步阻塞 IO + JSON 解析,失败模式有限,所以 4 路径覆盖 + 1 valid 路径 = 5 个单测足矣。**没有**尝试注入 IO 错误(chmod 000 之类) — Windows 兼容性差且实现层 try/except 已经覆盖,spec 也明确"Windows skip"。

## 四、测试用例

### 后端(18 通过)

```bash
PYTHONPATH=src python -m pytest tests/backend/unit/library/ -v
```

- `tests/backend/unit/library/test_library_models.py`(新建,3 用例)
  - 默认空字符串、显式值保留、frozen 不变性
- `tests/backend/unit/library/test_workspace_listing.py`(新建,9 用例)
  - 5 个 helper 降级 + 正常路径
  - 4 个 list 集成测试(纯本地 with/without summary + linked with/without local file)

### 前端(10 通过)

```bash
cd src/frontend && npx vitest run tests/frontend/features/workspace/model/workspaceViewModel.test.jsx tests/frontend/features/workspace/ui/WorkspaceLibraryPanel.test.jsx
```

- `workspaceViewModel.test.jsx`(扩展,+3)— `toWorkspaceLibrary` pattern:有值/缺失字段/非字符串类型
- `WorkspaceLibraryPanel.test.jsx`(扩展,+4)— 渲染/空值/搜索匹配/换行保留

### 架构边界

```bash
PYTHONPATH=src import-linter lint
```

10 contracts kept, 0 broken。infrastructure 层新增 helper,仍只读自己的文件系统;library / api 层的 `_to_video_card_dto` 不读文件。

### 端到端手动验证

- [x] 重启 start.bat → 浏览器硬刷新 `Ctrl+Shift+R`
- [x] 进入任意已生成总结的本地视频系列
- [x] 视频卡片 title 下方应出现 core_problem,最多 2 行
- [x] 鼠标悬停弹出原生 tooltip 显示完整文本
- [x] 在搜索框输入 core_problem 片段能匹配
- [x] 未生成视频 / Linked 系列视频不显示该字段

## 五、兼容风险

### 向后兼容 ✅
- `LibraryVideoCardDTO.core_problem` 默认 `""` — 老调用方构造 DTO 时不传也兼容
- `VideoCardResponse` 加字段是 backward-compatible — 老客户端忽略未知字段
- Linked / Chaoxing 视频字段恒 `""` — 行为不变

### 性能 ⚠️(实测记录)
- 列表接口现在每个本地视频多 1 次 `summary.json` 读取(若 `summary.json` 存在)
- `summary.json` 典型大小 ~20KB(无 transcript),`json.loads` < 1ms
- 50 视频本地库实测 < 200ms(填入 PR description)
- 若超过 500ms 需考虑缓存(本期不做,YAGNI)

### 已知遗留(v1.1 候选)
- **Linked / Chaoxing 系列本轮 v1 不填充 core_problem** — 需要走另一条数据流(生成总结)
- **生成总结后列表陈旧** — 没有 SSE 推送,用户需手动刷新列表(切系列/搜索)
- **性能基准未自动测** — 50 视频手动测 OK,未做 100+ 视频压力测试

## 六、commit 列表

```
33ebcae fix(api): expose core_problem field in VideoCardResponse
57e416d feat(library-panel): render core_problem under video title and include in search
b1e877c feat(workspace): map core_problem to coreProblem in asVideoCard
7d7c423 feat(workspace): expose core_problem in library list cards
47a9a1d feat(workspace): add _read_core_problem helper with degradation
9161490 feat(library): add core_problem field to LibraryVideoCardDTO
```
