### PR TITLE
Fix video citation seek anchors

### DIFF
--- a/src/backend/agent_graph/evidence/citations.py
+++ b/src/backend/agent_graph/evidence/citations.py
@@ -38,6 +38,7 @@ def build_citations_from_graph_result(result: dict[str, object]) -> list[Citatio
         return []
     retrieval_results = _with_source_numbers(retrieval_results)
     used_evidence_ids = _resolve_used_evidence_ids(result)
+    used_citation_ids = _resolve_used_citation_ids(result)
     if used_evidence_ids is not None:
         retrieval_results = [
             item for item in retrieval_results
@@ -90,6 +91,19 @@ def build_citations_from_graph_result(result: dict[str, object]) -> list[Citatio
             continue
 
         if source_type in {"transcript_chunk", "transcript_full"}:
+            segment_citations = _transcript_segment_citations(
+                item=item,
+                citation_id=citation_id,
+                title=title,
+                used_citation_ids=used_citation_ids,
+            )
+            if segment_citations:
+                citations.extend(segment_citations)
+                next_id += 1
+                continue
+            if used_citation_ids is not None:
+                next_id += 1
+                continue
             slot_candidates = _to_slot_candidates(item.get("matches"))
             best_match = item.get("best_match")
             if isinstance(best_match, dict):
@@ -170,6 +184,21 @@ def _resolve_used_evidence_ids(result: dict[str, object]) -> set[str] | None:
         return None
     if not isinstance(raw_ids, list):
         raise ValueError("used_evidence_ids 必须是数组。")
+    used_ids = {
+        item.strip()
+        for item in raw_ids
+        if isinstance(item, str) and item.strip()
+    }
+    return used_ids
+
+
+def _resolve_used_citation_ids(result: dict[str, object]) -> set[str] | None:
+    """从结果中提取回答实际引用过的 citation id 集合。"""
+    raw_ids = result.get("used_citation_ids")
+    if raw_ids is None:
+        return None
+    if not isinstance(raw_ids, list):
+        raise ValueError("used_citation_ids 必须是数组。")
     used_ids = {
         item.strip()
         for item in raw_ids
@@ -350,6 +379,59 @@ def _append_video_graph_items(citations: list[CitationReference], items: object,
         )
         next_id += 1
     return next_id
+
+
+def _transcript_segment_citations(
+    *,
+    item: dict[str, object],
+    citation_id: str,
+    title: str,
+    used_citation_ids: set[str] | None,
+) -> list[CitationReference]:
+    """把 transcript evidence 的 `segments` 展开为 `[N.M]` citation。"""
+    raw_segments = item.get("segments")
+    if not isinstance(raw_segments, list):
+        return []
+    citations: list[CitationReference] = []
+    for index, segment in enumerate(raw_segments, start=1):
+        if not isinstance(segment, dict):
+            continue
+        anchor_id = _as_str(segment.get("anchor_id")) or f"{citation_id}.{index}"
+        if used_citation_ids is not None and anchor_id not in used_citation_ids:
+            continue
+        start_seconds = _as_float(segment.get("start_seconds"))
+        if start_seconds is None:
+            continue
+        end_seconds = _as_float(segment.get("end_seconds"))
+        text = _as_str(segment.get("text"))
+        citations.append(
+            CitationReference(
+                id=anchor_id,
+                label=_as_str(item.get("slot_label")) or _as_str(item.get("label")) or title,
+                source_type="transcript",
+                search_scope="transcript",
+                slots=[
+                    CitationSlot(
+                        slot=1,
+                        target_type="video",
+                        video_id=str(item.get("video_id", "")).strip(),
+                        video_title=title,
+                        start_seconds=start_seconds,
+                        end_seconds=end_seconds,
+                    ),
+                    CitationSlot(
+                        slot=2,
+                        target_type="transcript",
+                        video_id=str(item.get("video_id", "")).strip(),
+                        video_title=title,
+                        start_seconds=start_seconds,
+                        end_seconds=end_seconds,
+                        text=text,
+                    ),
+                ],
+            )
+        )
+    return citations
 
 
 def _to_slot_candidates(matches: object) -> list[CitationSlotCandidate]:

--- a/src/backend/agent_graph/evidence/inline_citations.py
+++ b/src/backend/agent_graph/evidence/inline_citations.py
@@ -1,7 +1,7 @@
-"""解析与过滤 LLM 流式回答中的 inline 数字引用（`[1]` / `[2]` ...）。
+"""解析与过滤 LLM 流式回答中的 inline 数字引用（`[1]` / `[2.1]` ...）。
 
 提供三个职责单一的工具函数：
-- `resolve_inline_citations`：把回答中的 `[N]` 解析回 `evidence_id`，
+- `resolve_inline_citations`：把回答中的 `[N]` / `[N.M]` 解析回 `evidence_id`，
   并剥离任何误输出的内部 ID 标记（`e1`、`local-1`、`web-2` 等）；
 - `extract_inline_source_numbers`：上面那个函数的"只取编号"便捷封装；
 - `filter_inline_citation_markers`：按白名单只保留合法的 citation 编号。
@@ -16,8 +16,8 @@ import re
 from dataclasses import dataclass
 
 
-# 匹配回答正文中的 inline 数字引用 `[N]`（N 为十进制整数，允许带空白）。
-INLINE_NUMBER_PATTERN = re.compile(r"\[(?P<value>\s*\d+\s*)\]")
+# 匹配回答正文中的 inline 数字引用 `[N]` 或 transcript segment anchor `[N.M]`。
+INLINE_NUMBER_PATTERN = re.compile(r"\[(?P<value>\s*\d+(?:\.\d+)?\s*)\]")
 
 # 匹配模型在流式输出时可能误输出的内部 ID 标记（命中后直接整段删除）。
 EVIDENCE_ID_MARKER_PATTERN = re.compile(r"\[\s*(?:e+[0-9]+|local-\d+|web-\d+)\s*\]")
@@ -31,11 +31,13 @@ class InlineCitationResolution:
         answer_text: 去除内部 ID 标记后的回答正文。
         used_source_numbers: 回答中实际引用过的 source 编号（按出现顺序）。
         used_evidence_ids: 与 `used_source_numbers` 一一对应的 evidence_id 列表。
+        used_citation_ids: 回答中实际引用过的 citation id（按出现顺序）。
     """
 
     answer_text: str
     used_source_numbers: list[int]
     used_evidence_ids: list[str]
+    used_citation_ids: list[str]
 
 
 def extract_inline_source_numbers(
@@ -58,7 +60,7 @@ def resolve_inline_citations(
     answer_text: str,
     evidence_items: list[dict[str, object]],
 ) -> InlineCitationResolution:
-    """把回答中的 `[N]` 解析为 `evidence_id`，并清理内部 ID 标记。
+    """把回答中的 `[N]` / `[N.M]` 解析为 `evidence_id`，并清理内部 ID 标记。
 
     处理流程：
     1. 先用 `EVIDENCE_ID_MARKER_PATTERN` 把所有 `e1`、`local-1`、`web-2`
@@ -79,19 +81,21 @@ def resolve_inline_citations(
     Raises:
         ValueError: 模型输出了未在 `evidence_items` 中出现的引用编号。
     """
-    source_map = _build_source_number_map(evidence_items)
+    citation_map = _build_citation_map(evidence_items)
     used_numbers: list[int] = []
     used_ids: list[str] = []
-    unknown_numbers: list[int] = []
+    used_citation_ids: list[str] = []
+    unknown_numbers: list[str] = []
     cleaned_parts: list[str] = []
     last_index = 0
     answer_text = EVIDENCE_ID_MARKER_PATTERN.sub("", answer_text)
     for match in INLINE_NUMBER_PATTERN.finditer(answer_text):
         cleaned_parts.append(answer_text[last_index:match.start()])
-        source_number = int(match.group("value").strip())
-        evidence_id = source_map.get(source_number)
+        citation_id = match.group("value").strip()
+        source_number = int(citation_id.split(".", 1)[0])
+        evidence_id = citation_map.get(citation_id)
         if evidence_id is None:
-            unknown_numbers.append(source_number)
+            unknown_numbers.append(citation_id)
             cleaned_parts.append(match.group(0))
             last_index = match.end()
             continue
@@ -99,7 +103,9 @@ def resolve_inline_citations(
             used_numbers.append(source_number)
         if evidence_id not in used_ids:
             used_ids.append(evidence_id)
-        cleaned_parts.append(f"[{source_number}]")
+        if citation_id not in used_citation_ids:
+            used_citation_ids.append(citation_id)
+        cleaned_parts.append(f"[{citation_id}]")
         last_index = match.end()
     if unknown_numbers:
         joined_numbers = ", ".join(str(item) for item in dict.fromkeys(unknown_numbers))
@@ -109,6 +115,7 @@ def resolve_inline_citations(
         answer_text="".join(cleaned_parts),
         used_source_numbers=used_numbers,
         used_evidence_ids=used_ids,
+        used_citation_ids=used_citation_ids,
     )
 
 
@@ -120,7 +127,7 @@ def filter_inline_citation_markers(answer_text: str, available_ids: set[str]) ->
 
     Args:
         answer_text: 待过滤的原始回答文本。
-        available_ids: 允许保留的引用编号集合（元素为字符串形式的整数）。
+        available_ids: 允许保留的引用编号集合（元素为字符串形式的 citation id）。
 
     Returns:
         过滤后的文本；未知编号的 `[N]` 整段替换为空字符串。
@@ -150,18 +157,43 @@ def _as_evidence_id(item: dict[str, object]) -> str | None:
     return evidence_id or None
 
 
-def _build_source_number_map(evidence_items: list[dict[str, object]]) -> dict[int, str]:
-    """按列表顺序把 `evidence_items` 映射成 `编号 -> evidence_id` 字典。
+def _build_citation_map(evidence_items: list[dict[str, object]]) -> dict[str, str]:
+    """按列表顺序把 `evidence_items` 映射成 citation id 字典。
 
     Args:
         evidence_items: 上游注入的证据字典列表。
 
     Returns:
-        `编号` 从 1 开始、值为对应 `evidence_id` 的字典；缺 ID 的项被跳过。
+        `citation_id -> evidence_id` 字典；缺 ID 的项被跳过。
     """
-    source_map: dict[int, str] = {}
+    citation_map: dict[str, str] = {}
     for index, item in enumerate(evidence_items, start=1):
         evidence_id = _as_evidence_id(item)
         if evidence_id is not None:
-            source_map[index] = evidence_id
-    return source_map
+            source_number = _source_number(item, index)
+            segment_anchor_ids = _segment_anchor_ids(item.get("segments"))
+            if not segment_anchor_ids:
+                citation_map[str(source_number)] = evidence_id
+            for anchor_id in segment_anchor_ids:
+                citation_map[anchor_id] = evidence_id
+    return citation_map
+
+
+def _source_number(item: dict[str, object], fallback: int) -> int:
+    value = item.get("source_number")
+    if isinstance(value, int) and value > 0:
+        return value
+    return fallback
+
+
+def _segment_anchor_ids(raw_segments: object) -> list[str]:
+    if not isinstance(raw_segments, list):
+        return []
+    anchor_ids: list[str] = []
+    for segment in raw_segments:
+        if not isinstance(segment, dict):
+            continue
+        anchor_id = segment.get("anchor_id")
+        if isinstance(anchor_id, str) and re.fullmatch(r"\d+\.\d+", anchor_id.strip()):
+            anchor_ids.append(anchor_id.strip())
+    return anchor_ids

--- a/src/backend/agent_graph/evidence/transcript_anchors.py
+++ b/src/backend/agent_graph/evidence/transcript_anchors.py
@@ -1,0 +1,80 @@
+"""为 transcript evidence 注入可被模型引用的精确 segment anchors。"""
+
+from __future__ import annotations
+
+
+def number_evidence_items_for_citations(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    """为证据项注入 source 编号，并为 transcript segments 注入 `[N.M]` anchors。"""
+    return [
+        _with_source_anchor_fields(item, index)
+        for index, item in enumerate(items, start=1)
+    ]
+
+
+def _with_source_anchor_fields(item: dict[str, object], index: int) -> dict[str, object]:
+    numbered = {
+        **item,
+        "source_number": index,
+        "source_label": f"Source {index}",
+    }
+    source_type = str(item.get("source_type", "")).strip()
+    source_family = str(item.get("source_family", "")).strip()
+    if source_family != "transcript" and source_type not in {"transcript_chunk", "transcript_full"}:
+        return numbered
+    anchored_segments = _anchor_segments(item.get("segments"), index)
+    if not anchored_segments:
+        return numbered
+    return {
+        **numbered,
+        "segments": anchored_segments,
+        "text": _render_segment_anchor_lines(anchored_segments),
+        "snippet": _render_segment_anchor_lines(anchored_segments),
+    }
+
+
+def _anchor_segments(raw_segments: object, source_number: int) -> list[dict[str, object]]:
+    if not isinstance(raw_segments, list):
+        return []
+    segments: list[dict[str, object]] = []
+    for segment_index, raw_segment in enumerate(raw_segments, start=1):
+        if not isinstance(raw_segment, dict):
+            continue
+        text = _as_text(raw_segment.get("text"))
+        start_seconds = _as_float(raw_segment.get("start_seconds"))
+        end_seconds = _as_float(raw_segment.get("end_seconds"))
+        if not text or start_seconds is None:
+            continue
+        segments.append(
+            {
+                "anchor_id": f"{source_number}.{segment_index}",
+                "start_seconds": start_seconds,
+                "end_seconds": end_seconds,
+                "text": text,
+            }
+        )
+    return segments
+
+
+def _render_segment_anchor_lines(segments: list[dict[str, object]]) -> str:
+    return "\n".join(
+        f"[{segment['anchor_id']}] ({_format_seconds(segment['start_seconds'])}) {segment['text']}"
+        for segment in segments
+    )
+
+
+def _format_seconds(value: object) -> str:
+    seconds = int(float(value))
+    minutes, second = divmod(seconds, 60)
+    return f"{minutes:02d}:{second:02d}"
+
+
+def _as_text(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None

--- a/src/backend/agent_graph/query/series_answer_synthesizer.py
+++ b/src/backend/agent_graph/query/series_answer_synthesizer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 
 from backend.agent.schemas.messages import AgentChatMessage
+from backend.agent_graph.evidence.transcript_anchors import number_evidence_items_for_citations
 from backend.agent_graph.prompts import (
     SERIES_ANSWER_SYNTHESIZER_SYSTEM_PROMPT,
     build_answer_detail_level_prompt,
@@ -137,7 +138,7 @@ class SeriesAnswerSynthesizer:
         return self._build_messages(
             user_message=user_message,
             query_understanding=query_understanding,
-            evidence_items=_number_evidence_items(normalized_evidence_items),
+            evidence_items=number_evidence_items_for_citations(normalized_evidence_items),
             series_catalog=series_catalog or {},
             memory_messages=memory_messages or [],
             text_only=True,
@@ -229,34 +230,15 @@ def _normalize_evidence_items(
 
 # 追加到流式输出 system prompt 末尾的约束片段。
 #
-# 目的：让模型在流式输出场景下只产出 Markdown 回答正文 + `[1]`/`[2]`
-# 形式的数字引用，不要输出 JSON、citations、used_source_types 等结构化
+# 目的：让模型在流式输出场景下只产出 Markdown 回答正文 + citation
+# marker，不要输出 JSON、citations、used_source_types 等结构化
 # 字段，也不要暴露 evidence_id、local-*、web-*、e* 等内部 ID。
 _STREAMING_CITED_ANSWER_PROMPT = (
     "\n流式引用输出要求：\n"
     "- 只输出 answer 字段对应的 Markdown 回答正文。\n"
     "- evidence_items 已按 Source 1、Source 2 等数字编号。\n"
-    "- 使用某条 Source 支持句子或段落时，在该句或段落末尾插入对应的数字引用，例如 [1] 或 [2]。\n"
-    "- 只能使用真实存在的 Source 编号，不要输出 evidence_id、local-*、web-* 或 e* 这类内部 ID，不要编造引用编号。\n"
+    "- summary / web evidence 使用 Source 编号引用，例如 [1] 或 [2]。\n"
+    "- transcript evidence 如果包含 segments，必须使用 segment 的 anchor_id 引用，例如 [2.1]，不要用粗粒度 [2]。\n"
+    "- 只能使用真实存在的 Source 编号或 transcript anchor_id，不要输出 evidence_id、local-*、web-* 或 e* 这类内部 ID，不要编造引用编号。\n"
     "- 不要输出 JSON，不要输出 citations 或 used_source_types 字段。\n"
 )
-
-
-def _number_evidence_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
-    """为证据项注入 `source_number` 与 `source_label`，用于流式引用编号。
-
-    Args:
-        items: 待编号的证据字典列表。
-
-    Returns:
-        长度与输入一致、每项多了 `source_number`（从 1 开始）和
-        `source_label`（形如 `Source 1`）的新字典列表。
-    """
-    return [
-        {
-            **item,
-            "source_number": index,
-            "source_label": f"Source {index}",
-        }
-        for index, item in enumerate(items, start=1)
-    ]

--- a/src/backend/agent_graph/query/video_answer_synthesizer.py
+++ b/src/backend/agent_graph/query/video_answer_synthesizer.py
@@ -13,6 +13,7 @@ import json
 from pydantic import BaseModel
 
 from backend.agent.schemas.messages import AgentChatMessage
+from backend.agent_graph.evidence.transcript_anchors import number_evidence_items_for_citations
 from backend.agent_graph.prompts import (
     VIDEO_ANSWER_SYNTHESIZER_SYSTEM_PROMPT,
     build_answer_detail_level_prompt,
@@ -125,7 +126,7 @@ class AnswerSynthesisProgram:
         return self._build_messages(
             user_message=user_message,
             memory_messages=memory_messages or [],
-            evidence_items=_number_evidence_items(normalized_evidence_items),
+            evidence_items=number_evidence_items_for_citations(normalized_evidence_items),
             meta_state=meta_state or {},
             text_only=True,
         )
@@ -183,33 +184,14 @@ class AnswerSynthesisProgram:
 
 # 追加到流式输出 system prompt 末尾的约束片段。
 #
-# 目的：让模型在流式输出场景下只产出 Markdown 回答正文 + `[1]`/`[2]`
-# 形式的数字引用，不要输出 JSON、doc_id 等内部 ID，也不要输出额外字段。
+# 目的：让模型在流式输出场景下只产出 Markdown 回答正文 + citation
+# marker，不要输出 JSON、doc_id 等内部 ID，也不要输出额外字段。
 _STREAMING_CITED_ANSWER_PROMPT = (
     "\n流式引用输出要求：\n"
     "- 只输出 answer 字段对应的 Markdown 回答正文。\n"
     "- evidence_items 已按 Source 1、Source 2 等数字编号。\n"
-    "- 使用某条 Source 支持句子或段落时，在该句或段落末尾插入对应的数字引用，例如 [1] 或 [2]。\n"
-    "- 只能使用真实存在的 Source 编号，不要输出 evidence_id、local-*、web-* 或 e* 这类内部 ID，不要编造引用编号。\n"
+    "- summary / web evidence 使用 Source 编号引用，例如 [1] 或 [2]。\n"
+    "- transcript evidence 如果包含 segments，必须使用 segment 的 anchor_id 引用，例如 [2.1]，不要用粗粒度 [2]。\n"
+    "- 只能使用真实存在的 Source 编号或 transcript anchor_id，不要输出 evidence_id、local-*、web-* 或 e* 这类内部 ID，不要编造引用编号。\n"
     "- 不要输出 JSON，不要输出额外字段。\n"
 )
-
-
-def _number_evidence_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
-    """为证据项注入 `source_number` 与 `source_label`，用于流式引用编号。
-
-    Args:
-        items: 待编号的证据字典列表。
-
-    Returns:
-        长度与输入一致、每项多了 `source_number`（从 1 开始）和
-        `source_label`（形如 `Source 1`）的新字典列表。
-    """
-    return [
-        {
-            **item,
-            "source_number": index,
-            "source_label": f"Source {index}",
-        }
-        for index, item in enumerate(items, start=1)
-    ]

--- a/src/backend/agent_graph/runtime/nodes.py
+++ b/src/backend/agent_graph/runtime/nodes.py
@@ -799,11 +799,21 @@ def _build_full_transcript_context_item(transcript) -> dict[str, object] | None:
     if transcript is None:
         return None
     lines: list[str] = []
+    segments: list[dict[str, object]] = []
     for segment in getattr(transcript, "segments", []):
         text = str(getattr(segment, "text", "")).strip()
         if not text:
             continue
-        lines.append(f"[{_format_seconds(getattr(segment, 'start_seconds', 0.0))}] {text}")
+        start_seconds = getattr(segment, "start_seconds", None)
+        end_seconds = getattr(segment, "end_seconds", None)
+        lines.append(f"[{_format_seconds(start_seconds or 0.0)}] {text}")
+        segments.append(
+            {
+                "start_seconds": start_seconds,
+                "end_seconds": end_seconds,
+                "text": text,
+            }
+        )
     text = "\n".join(lines).strip()
     if not text:
         return None
@@ -818,6 +828,7 @@ def _build_full_transcript_context_item(transcript) -> dict[str, object] | None:
         "end_seconds": getattr(transcript, "segments", [None])[-1].end_seconds if getattr(transcript, "segments", []) else None,
         "text": text,
         "snippet": text,
+        "segments": segments,
     }
 
 

--- a/src/backend/agent_graph/runtime/streaming.py
+++ b/src/backend/agent_graph/runtime/streaming.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from backend.agent.schemas.chat_stream import ChatCompletionStreamChunk
 from backend.agent.schemas.stream_events import AgentStreamEvent
 from backend.agent_graph.evidence.inline_citations import filter_inline_citation_markers, resolve_inline_citations
+from backend.agent_graph.evidence.transcript_anchors import number_evidence_items_for_citations
 from backend.agent_graph.runtime.node_catalog import get_node_alias
 from backend.agent_graph.runtime.outcome import extract_assistant_message, extract_tool_results
 
@@ -465,7 +466,8 @@ def _graph_evidence_items(result: dict[str, object]) -> list[dict[str, object]]:
     raw_items = result.get("evidence_items", result.get("retrieval_results", []))
     if not isinstance(raw_items, list):
         return []
-    return [item for item in raw_items if isinstance(item, dict)]
+    evidence_items = [item for item in raw_items if isinstance(item, dict)]
+    return number_evidence_items_for_citations(evidence_items)
 
 
 def _duration_ms(start: datetime | None, end: datetime | None) -> int | None:

--- a/src/backend/agent_graph/runtime/streaming.py
+++ b/src/backend/agent_graph/runtime/streaming.py
@@ -373,6 +373,7 @@ class AgentGraphStreamOrchestrator:
         )
         assistant_message = citation_resolution.answer_text
         used_evidence_ids = citation_resolution.used_evidence_ids
+        used_citation_ids = citation_resolution.used_citation_ids
 
         stream_finished_at = _current_time_like(stream_started_at)
         result = {
@@ -380,6 +381,7 @@ class AgentGraphStreamOrchestrator:
             "answer": assistant_message,
             "assistant_message": assistant_message,
             "used_evidence_ids": used_evidence_ids,
+            "used_citation_ids": used_citation_ids,
         }
         if debug_trace is not None:
             debug_trace["graph_result"] = result

--- a/src/backend/api/di/container.py
+++ b/src/backend/api/di/container.py
@@ -12,11 +12,16 @@ from pathlib import Path
 from fastapi import Depends, Request
 
 from backend.api.di.bootstrap import ApiContainer, build_api_container
+from backend.video_summary.infrastructure.config.settings import ensure_settings_file
 
 
-def _resolve_root_dir() -> Path:
-    for candidate in Path(__file__).resolve().parents:
-        if (candidate / "config" / "settings.toml").is_file():
+def _resolve_root_dir(start_path: Path | None = None) -> Path:
+    resolved_start = start_path or Path(__file__).resolve()
+    for candidate in resolved_start.parents:
+        settings_path = candidate / "config" / "settings.toml"
+        example_path = candidate / "config" / "settings.toml.example"
+        if settings_path.is_file() or example_path.is_file():
+            ensure_settings_file(settings_path)
             return candidate
     raise FileNotFoundError("settings file not found in parent config directories")
 

--- a/src/backend/video_summary/infrastructure/rag/agent_memory/retrieval.py
+++ b/src/backend/video_summary/infrastructure/rag/agent_memory/retrieval.py
@@ -1176,12 +1176,27 @@ def _expand_transcript_hit(
     ]
     if not segments:
         return hit
+    segment_items = [
+        {
+            "start_seconds": segment.start_seconds,
+            "end_seconds": segment.end_seconds,
+            "text": segment.text,
+        }
+        for segment in segments
+        if str(segment.text).strip()
+    ]
     return {
         **hit,
+        "best_match": {
+            "start_seconds": hit.get("start_seconds"),
+            "end_seconds": hit.get("end_seconds"),
+            "text": hit.get("text") or hit.get("snippet"),
+        },
         "start_seconds": segments[0].start_seconds,
         "end_seconds": segments[-1].end_seconds,
         "text": " ".join(segment.text for segment in segments),
         "snippet": " ".join(segment.text for segment in segments),
+        "segments": segment_items,
     }
 
 

--- a/src/frontend/src/features/workspace/ui/WorkspaceChatPanel.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceChatPanel.jsx
@@ -114,7 +114,11 @@ export function WorkspaceChatPanel({
 
     return (
       <Suspense fallback={<AssistantMessageFallback content={message.content} />}>
-        <WorkspaceMarkdownMessage content={message.content} citations={message.citations} />
+        <WorkspaceMarkdownMessage
+          content={message.content}
+          citations={message.citations}
+          onOpenSeekReference={onOpenSeekReference}
+        />
       </Suspense>
     );
   }

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceMarkdownMessage.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceMarkdownMessage.jsx
@@ -38,7 +38,7 @@ function injectCitationLinks(content, citations) {
     return content;
   }
   const citationIds = new Set(citations.map((citation) => citation.id));
-  return content.replace(/\[(\d+)\]/g, (match, citationId) => {
+  return content.replace(/\[(\d+(?:\.\d+)?)\]/g, (match, citationId) => {
     if (!citationIds.has(citationId)) {
       return match;
     }

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceMarkdownMessage.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceMarkdownMessage.jsx
@@ -119,6 +119,26 @@ function buildCitationPreview(citation) {
   };
 }
 
+function buildCitationSeekReference(citation) {
+  if (!citation || typeof citation !== "object") {
+    return null;
+  }
+  const slots = Array.isArray(citation.slots) ? citation.slots.filter((slot) => slot && typeof slot === "object") : [];
+  const videoSlot = slots.find((slot) => slot.target_type === "video" && typeof slot.start_seconds === "number");
+  if (!videoSlot) {
+    return null;
+  }
+  const transcriptSlot = slots.find((slot) => slot.target_type === "transcript" && typeof slot.text === "string" && slot.text.trim());
+  const matchedText = transcriptSlot?.text?.trim() ?? "";
+  return {
+    seconds: videoSlot.start_seconds,
+    endSeconds: typeof videoSlot.end_seconds === "number" ? videoSlot.end_seconds : null,
+    matchedText,
+    chapterTitle: typeof videoSlot.video_title === "string" ? videoSlot.video_title.trim() : "",
+    query: "",
+  };
+}
+
 function resolveCitationPreviewPosition(anchor) {
   const rect = anchor.getBoundingClientRect();
   const viewportWidth = window.innerWidth || document.documentElement.clientWidth || CITATION_PREVIEW_WIDTH;
@@ -179,7 +199,7 @@ function CitationPreviewCard({ preview, position }) {
   );
 }
 
-function CitationLink({ href, children, preview, ...props }) {
+function CitationLink({ href, children, preview, seekReference, onOpenSeekReference, ...props }) {
   const [position, setPosition] = useState(null);
 
   function showPreview(event) {
@@ -193,12 +213,19 @@ function CitationLink({ href, children, preview, ...props }) {
     setPosition(null);
   }
 
+  function handleClick(event) {
+    event.preventDefault();
+    if (seekReference) {
+      onOpenSeekReference?.(seekReference);
+    }
+  }
+
   return (
     <span className="inline-flex align-baseline">
       <a
         {...props}
         href={href}
-        onClick={(event) => event.preventDefault()}
+        onClick={handleClick}
         onMouseEnter={showPreview}
         onMouseLeave={hidePreview}
         onFocus={showPreview}
@@ -230,7 +257,7 @@ function ThinkBlock({ content }) {
   );
 }
 
-function MarkdownSegment({ content, citations }) {
+function MarkdownSegment({ content, citations, onOpenSeekReference }) {
   const normalizedCitations = normalizeCitations(citations);
   const renderedContent = injectCitationLinks(normalizeMathDelimiters(content), normalizedCitations);
   const citationMap = new Map(normalizedCitations.map((citation) => [citation.id, citation]));
@@ -242,9 +269,17 @@ function MarkdownSegment({ content, citations }) {
         a: ({ node: _node, href, children, ...props }) => {
           if (typeof href === "string" && href.startsWith("#citation-")) {
             const citationId = href.replace("#citation-", "");
-            const preview = buildCitationPreview(citationMap.get(citationId));
+            const citation = citationMap.get(citationId);
+            const preview = buildCitationPreview(citation);
+            const seekReference = buildCitationSeekReference(citation);
             return (
-              <CitationLink {...props} href={href} preview={preview}>
+              <CitationLink
+                {...props}
+                href={href}
+                preview={preview}
+                seekReference={seekReference}
+                onOpenSeekReference={onOpenSeekReference}
+              >
                 {children}
               </CitationLink>
             );
@@ -268,7 +303,7 @@ function MarkdownSegment({ content, citations }) {
   );
 }
 
-export function WorkspaceMarkdownMessage({ content, citations = null }) {
+export function WorkspaceMarkdownMessage({ content, citations = null, onOpenSeekReference }) {
   const parts = splitThinkBlocks(content);
   return (
     <div className="flex flex-col gap-4">
@@ -276,7 +311,12 @@ export function WorkspaceMarkdownMessage({ content, citations = null }) {
         part.type === "think" ? (
           <ThinkBlock key={`${part.type}-${index}`} content={part.content} />
         ) : (
-          <MarkdownSegment key={`${part.type}-${index}`} content={part.content} citations={citations} />
+          <MarkdownSegment
+            key={`${part.type}-${index}`}
+            content={part.content}
+            citations={citations}
+            onOpenSeekReference={onOpenSeekReference}
+          />
         )
       ))}
     </div>

--- a/tests/backend/integration/agent/test_series_scope_contracts.py
+++ b/tests/backend/integration/agent/test_series_scope_contracts.py
@@ -16,6 +16,7 @@ from backend.agent_graph.query.models import (
     SeriesQueryUnderstanding,
 )
 from backend.agent_graph.query.series_answer_synthesizer import SeriesAnswerSynthesizer
+from backend.agent_graph.query.video_answer_synthesizer import AnswerSynthesisProgram
 from backend.agent_graph.query.series_query_processor import SeriesQueryProcessor
 from backend.agent_graph.runtime.graph import build_agent_graph
 from backend.agent_graph.runtime.service import AgentGraphService
@@ -927,6 +928,58 @@ class SeriesScopeContractTests(unittest.TestCase):
         self.assertNotIn("[local-1]", resolution.answer_text)
         self.assertIn("[React](https://example.com)", resolution.answer_text)
 
+    def test_inline_citation_resolution_accepts_transcript_segment_anchor(self) -> None:
+        resolution = resolve_inline_citations(
+            "这里引用的是字幕里的精确片段。[2.1]",
+            [
+                {"evidence_id": "local-1", "source_number": 1},
+                {
+                    "evidence_id": "local-2",
+                    "source_number": 2,
+                    "segments": [
+                        {"anchor_id": "2.1", "start_seconds": 12.0, "end_seconds": 18.0, "text": "精确片段"},
+                    ],
+                },
+            ],
+        )
+
+        self.assertEqual(resolution.answer_text, "这里引用的是字幕里的精确片段。[2.1]")
+        self.assertEqual(resolution.used_source_numbers, [2])
+        self.assertEqual(resolution.used_evidence_ids, ["local-2"])
+        self.assertEqual(resolution.used_citation_ids, ["2.1"])
+
+    def test_inline_citation_resolution_rejects_unknown_transcript_segment_anchor(self) -> None:
+        with self.assertRaisesRegex(ValueError, "未知引用编号"):
+            resolve_inline_citations(
+                "这里引用的是不存在的字幕片段。[2.99]",
+                [
+                    {"evidence_id": "local-1", "source_number": 1},
+                    {
+                        "evidence_id": "local-2",
+                        "source_number": 2,
+                        "segments": [
+                            {"anchor_id": "2.1", "start_seconds": 12.0, "end_seconds": 18.0, "text": "精确片段"},
+                        ],
+                    },
+                ],
+            )
+
+    def test_inline_citation_resolution_rejects_broad_transcript_citation_when_segments_exist(self) -> None:
+        with self.assertRaisesRegex(ValueError, "未知引用编号"):
+            resolve_inline_citations(
+                "这里引用的是过宽的字幕来源。[2]",
+                [
+                    {"evidence_id": "local-1", "source_number": 1},
+                    {
+                        "evidence_id": "local-2",
+                        "source_number": 2,
+                        "segments": [
+                            {"anchor_id": "2.1", "start_seconds": 12.0, "end_seconds": 18.0, "text": "精确片段"},
+                        ],
+                    },
+                ],
+            )
+
     def test_citation_builder_uses_source_number_as_citation_id(self) -> None:
         turn = AgentGraphTurnBuilder().build(
             context=AgentContext(session_id="s1", scope_type="video", series_id="series-1", video_id="video-1"),
@@ -1038,6 +1091,80 @@ class SeriesScopeContractTests(unittest.TestCase):
         self.assertEqual(citation.slots[0].end_seconds, 70.0)
         self.assertEqual(citation.slots[1].target_type, "transcript")
         self.assertEqual(citation.slots[1].text, "完整字幕内容")
+
+    def test_citation_builder_uses_transcript_segment_anchor_time(self) -> None:
+        turn = AgentGraphTurnBuilder().build(
+            context=AgentContext(session_id="s1", scope_type="video", series_id="series-1", video_id="video-1"),
+            result={
+                "assistant_message": "answer [2.2]",
+                "answer": "answer [2.2]",
+                "used_evidence_ids": ["local-2"],
+                "used_citation_ids": ["2.2"],
+                "evidence_items": [
+                    {
+                        "evidence_id": "local-2",
+                        "source_number": 2,
+                        "series_id": "series-1",
+                        "video_id": "video-1",
+                        "title": "Video 1",
+                        "source_type": "transcript_chunk",
+                        "source_family": "transcript",
+                        "start_seconds": 0.0,
+                        "end_seconds": 700.0,
+                        "text": "扩展窗口字幕",
+                        "snippet": "扩展窗口字幕",
+                        "segments": [
+                            {"anchor_id": "2.1", "start_seconds": 10.0, "end_seconds": 15.0, "text": "第一句"},
+                            {"anchor_id": "2.2", "start_seconds": 42.0, "end_seconds": 47.0, "text": "第二句"},
+                        ],
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(len(turn.citations), 1)
+        citation = turn.citations[0]
+        self.assertEqual(citation.id, "2.2")
+        self.assertEqual(citation.source_type, "transcript")
+        self.assertEqual(citation.slots[0].start_seconds, 42.0)
+        self.assertEqual(citation.slots[0].end_seconds, 47.0)
+        self.assertEqual(citation.slots[1].text, "第二句")
+
+    def test_video_answer_stream_messages_render_transcript_full_segment_anchors(self) -> None:
+        program = AnswerSynthesisProgram(gateway=FakeAnswerGateway())
+
+        messages = program.build_text_messages(
+            user_message="这里讲了什么？",
+            evidence_items=[
+                {
+                    "evidence_id": "local-1",
+                    "series_id": "series-1",
+                    "video_id": "video-1",
+                    "title": "Video 1",
+                    "source_type": "summary_global",
+                    "source_family": "summary",
+                    "text": "summary",
+                    "snippet": "summary",
+                },
+                {
+                    "evidence_id": "local-2",
+                    "series_id": "series-1",
+                    "video_id": "video-1",
+                    "title": "Video 1",
+                    "source_type": "transcript_full",
+                    "source_family": "transcript",
+                    "segments": [
+                        {"start_seconds": 12.0, "end_seconds": 18.0, "text": "第一句"},
+                        {"start_seconds": 42.0, "end_seconds": 47.0, "text": "第二句"},
+                    ],
+                },
+            ],
+        )
+
+        user_content = messages[1].content
+        self.assertIn("[2.1] (00:12) 第一句", user_content)
+        self.assertIn("[2.2] (00:42) 第二句", user_content)
+        self.assertIn("必须使用 segment 的 anchor_id", messages[0].content)
 
 
 class FakeQueryGateway:

--- a/tests/backend/unit/api/test_container_config_resolution.py
+++ b/tests/backend/unit/api/test_container_config_resolution.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class ContainerConfigResolutionTests(unittest.TestCase):
+    def test_container_import_creates_settings_from_example_when_missing(self) -> None:
+        container = importlib.import_module("backend.api.di.container")
+        example_content = "example settings"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_dir = Path(temp_dir)
+            config_dir = root_dir / "config"
+            config_dir.mkdir()
+            example_path = config_dir / "settings.toml.example"
+            example_path.write_text(example_content, encoding="utf-8")
+            start_path = root_dir / "src" / "backend" / "api" / "di" / "container.py"
+            start_path.parent.mkdir(parents=True)
+            start_path.write_text("", encoding="utf-8")
+
+            resolved_root = container._resolve_root_dir(start_path)
+
+            config_path = config_dir / "settings.toml"
+            self.assertEqual(resolved_root, root_dir)
+            self.assertTrue(config_path.exists())
+            self.assertEqual(config_path.read_text(encoding="utf-8"), example_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/frontend/features/workspace/ui/shared/WorkspaceMarkdownMessage.test.jsx
+++ b/tests/frontend/features/workspace/ui/shared/WorkspaceMarkdownMessage.test.jsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { WorkspaceMarkdownMessage } from "@src/features/workspace/ui/shared/WorkspaceMarkdownMessage";
 
@@ -73,6 +73,49 @@ describe("WorkspaceMarkdownMessage", () => {
     expect(screen.getByText("[2] Video 1")).toBeInTheDocument();
     expect(screen.queryByText(longText)).not.toBeInTheDocument();
     expect(screen.getByText(/^字幕内容.*\.\.\.$/)).toBeInTheDocument();
+  });
+
+  it("opens video seek references when clicking transcript citations", () => {
+    const onOpenSeekReference = vi.fn();
+
+    render(
+      <WorkspaceMarkdownMessage
+        content="这里讲到了关键知识点。[1]"
+        citations={[
+          {
+            id: "1",
+            label: "Video 1",
+            source_type: "transcript",
+            slots: [
+              {
+                slot: 1,
+                target_type: "video",
+                video_title: "Video 1",
+                start_seconds: 42,
+                end_seconds: 55,
+              },
+              {
+                slot: 2,
+                target_type: "transcript",
+                video_title: "Video 1",
+                text: "关键知识点对应的字幕",
+              },
+            ],
+          },
+        ]}
+        onOpenSeekReference={onOpenSeekReference}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "1" }));
+
+    expect(onOpenSeekReference).toHaveBeenCalledWith({
+      seconds: 42,
+      endSeconds: 55,
+      matchedText: "关键知识点对应的字幕",
+      chapterTitle: "Video 1",
+      query: "",
+    });
   });
 
   it("renders model think tags as a collapsible thinking block", () => {

--- a/tests/frontend/features/workspace/ui/shared/WorkspaceMarkdownMessage.test.jsx
+++ b/tests/frontend/features/workspace/ui/shared/WorkspaceMarkdownMessage.test.jsx
@@ -118,6 +118,49 @@ describe("WorkspaceMarkdownMessage", () => {
     });
   });
 
+  it("opens video seek references for transcript segment citation anchors", () => {
+    const onOpenSeekReference = vi.fn();
+
+    render(
+      <WorkspaceMarkdownMessage
+        content="这里讲到了关键知识点。[2.1]"
+        citations={[
+          {
+            id: "2.1",
+            label: "Video 1",
+            source_type: "transcript",
+            slots: [
+              {
+                slot: 1,
+                target_type: "video",
+                video_title: "Video 1",
+                start_seconds: 12,
+                end_seconds: 18,
+              },
+              {
+                slot: 2,
+                target_type: "transcript",
+                video_title: "Video 1",
+                text: "关键知识点对应的精确字幕",
+              },
+            ],
+          },
+        ]}
+        onOpenSeekReference={onOpenSeekReference}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "2.1" }));
+
+    expect(onOpenSeekReference).toHaveBeenCalledWith({
+      seconds: 12,
+      endSeconds: 18,
+      matchedText: "关键知识点对应的精确字幕",
+      chapterTitle: "Video 1",
+      query: "",
+    });
+  });
+
   it("renders model think tags as a collapsible thinking block", () => {
     render(
       <WorkspaceMarkdownMessage


### PR DESCRIPTION
## Summary
- Add transcript segment citation anchors like `[2.1]` so video-centered chat citations seek to precise transcript segments instead of broad transcript windows.
- Keep summary citations non-seeking while supporting both `transcript_chunk` and `transcript_full` segment anchors.
- Initialize missing `config/settings.toml` from the example file to avoid startup failure on fresh worktrees.

## Test Plan
- `pytest tests\backend\integration\agent\test_series_scope_contracts.py`
- `npm test`
- `npm run build`

Fixes #37