### PR TITLE
feat: support hardlinked local media imports

### DIFF
--- a/src/backend/api/local_media_picker.py
+++ b/src/backend/api/local_media_picker.py
@@ -1,0 +1,37 @@
+"""本机媒体文件选择器。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+
+
+_PICKER_LOCK = Lock()
+_FILE_TYPES = [
+    ("媒体文件", "*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.m4a *.aac *.flac *.ogg *.opus *.wma"),
+    ("所有文件", "*.*"),
+]
+
+
+def select_local_media_paths() -> list[str]:
+    """打开系统文件选择框，返回用户确认的绝对媒体路径。"""
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+    except ImportError as error:
+        raise RuntimeError("当前运行环境不支持本机文件选择。") from error
+
+    with _PICKER_LOCK:
+        root = tk.Tk()
+        root.withdraw()
+        root.attributes("-topmost", True)
+        try:
+            selected_paths = filedialog.askopenfilenames(
+                title="选择媒体文件",
+                filetypes=_FILE_TYPES,
+                parent=root,
+            )
+        finally:
+            root.destroy()
+
+    return [str(Path(path).resolve()) for path in selected_paths]

--- a/src/backend/api/routes/videos.py
+++ b/src/backend/api/routes/videos.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import json
 import mimetypes
+from pathlib import Path
 from threading import Lock
 from urllib.parse import quote
 
@@ -17,11 +18,14 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse, PlainTextResponse, Response, StreamingResponse
 
 from backend.api.di.container import ApiContainerDep
+from backend.api.local_media_picker import select_local_media_paths
 from backend.api.schemas.contracts import (
     CancelSeriesSummariesRequest,
     CreateVideoNoteRequest,
     GenerateSeriesSummariesRequest,
     GenerateVideoSummaryRequest,
+    LocalMediaPathImportRequest,
+    LocalMediaSeriesPathImportRequest,
     UpdateVideoNoteRequest,
 )
 from backend.api.schemas.responses import (
@@ -994,6 +998,77 @@ def delete_video_source(series_id: str, video_id: str, container: ApiContainerDe
     except LookupError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
     return {"status": "deleted", "series_id": deleted.series_id, "video_id": deleted.video_id}
+
+
+@router.post("/api/import/local/select")
+def select_local_media(container: ApiContainerDep) -> dict[str, object]:
+    """POST /api/import/local/select — 由本机后端打开媒体文件选择框。"""
+    try:
+        source_paths = select_local_media_paths()
+        workspace_device = container.root_dir.stat().st_dev
+        incompatible_paths = [
+            Path(path).name
+            for path in source_paths
+            if Path(path).stat().st_dev != workspace_device
+        ]
+        return {
+            "source_paths": source_paths,
+            "hardlink_available": not incompatible_paths,
+            "incompatible_source_names": incompatible_paths,
+        }
+    except Exception as error:
+        raise HTTPException(status_code=503, detail=f"无法打开本机文件选择框：{error}") from error
+
+
+@router.post("/api/import/local/series/from-paths", response_model=SeriesResponse)
+def import_local_series_from_paths(
+    request: LocalMediaSeriesPathImportRequest,
+    container: ApiContainerDep,
+) -> SeriesResponse:
+    """POST /api/import/local/series/from-paths — 从本机路径新建系列。"""
+    if request.storage_mode is None:
+        raise HTTPException(status_code=400, detail="storage_mode 不能为空。")
+    try:
+        series = container.import_local_series.run_from_paths(
+            title=request.series_title,
+            source_paths=[Path(path) for path in request.source_paths],
+            storage_mode=request.storage_mode,
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return SeriesResponse.from_model(series)
+
+
+@router.post("/api/import/local/playground/from-paths", response_model=list[VideoCardResponse])
+def import_local_playground_videos_from_paths(
+    request: LocalMediaPathImportRequest,
+    container: ApiContainerDep,
+) -> list[VideoCardResponse]:
+    """POST /api/import/local/playground/from-paths — 从本机路径复制到 Playground。"""
+    try:
+        videos = container.import_local_playground_videos.run_from_paths(
+            source_paths=[Path(path) for path in request.source_paths],
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return [VideoCardResponse.from_model(video) for video in videos]
+
+
+@router.post("/api/import/local/series/{series_id}/from-paths", response_model=list[VideoCardResponse])
+def import_local_series_videos_from_paths(
+    series_id: str,
+    request: LocalMediaPathImportRequest,
+    container: ApiContainerDep,
+) -> list[VideoCardResponse]:
+    """POST /api/import/local/series/{series_id}/from-paths — 按系列模式追加本机媒体。"""
+    try:
+        videos = container.import_local_series_videos.run_from_paths(
+            series_id=series_id,
+            source_paths=[Path(path) for path in request.source_paths],
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return [VideoCardResponse.from_model(video) for video in videos]
 
 
 @router.post("/api/import/local/series", response_model=SeriesResponse)

--- a/src/backend/api/schemas/contracts.py
+++ b/src/backend/api/schemas/contracts.py
@@ -66,6 +66,19 @@ class UpdateVideoNoteRequest(BaseModel):
     content: str
 
 
+class LocalMediaPathImportRequest(BaseModel):
+    """从运行后端的本机文件系统导入媒体。"""
+
+    source_paths: list[str] = Field(min_length=1)
+    storage_mode: str | None = None
+
+
+class LocalMediaSeriesPathImportRequest(LocalMediaPathImportRequest):
+    """从本机路径创建系列的请求。"""
+
+    series_title: str = Field(min_length=1, max_length=200)
+
+
 class WorkspaceSettingsResponse(BaseModel):
     """工作区全局设置的响应模型。
 

--- a/src/backend/video_summary/infrastructure/storage/filesystem_video_workspace.py
+++ b/src/backend/video_summary/infrastructure/storage/filesystem_video_workspace.py
@@ -5,7 +5,7 @@
 
 - 把视频库中的"系列 / 视频 / 制品"以目录 + JSON 文件的形式落到磁盘；
 - 提供笔记等需要"按视频串行化"的写入能力（基于 `KeyedLockManager`）；
-- 在导入系列 / 视频时做去重、原子复制与失败回滚；
+- 在导入系列 / 视频时做去重、复制或硬链接与失败回滚；
 - 在删除系列 / 视频时同步清理本地媒体与制品目录，必要时回写 linked 元数据。
 
 目录布局约定：
@@ -59,6 +59,7 @@ from backend.video_summary.library.models import (
 VIDEO_SUFFIXES = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v"}
 AUDIO_SUFFIXES = {".mp3", ".wav", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wma"}
 MEDIA_SUFFIXES = VIDEO_SUFFIXES | AUDIO_SUFFIXES
+STORAGE_MODES = {"copy", "hardlink"}
 
 LINKED_SERIES_META_FILE = "linked_series.json"
 SERIES_META_FILE = "series_meta.json"
@@ -651,8 +652,46 @@ class FileSystemVideoWorkspace:
 
         try:
             series_dir.mkdir(parents=True, exist_ok=False)
-            self._write_series_title(series_id, title.strip())
+            self._write_series_meta(series_id, title.strip(), storage_mode="copy")
             self._copy_video_streams(series_dir=series_dir, files=files)
+            return LibrarySeriesDTO(
+                id=series_id,
+                title=title.strip(),
+                videos=self._list_videos_for_series(series_dir),
+            )
+        except Exception:
+            if series_dir.exists():
+                shutil.rmtree(series_dir)
+            meta_path = self._workspace_dir / series_id / SERIES_META_FILE
+            if meta_path.exists():
+                meta_path.unlink()
+            raise
+
+    def import_local_series_from_paths(
+        self,
+        *,
+        title: str,
+        source_paths: list[Path],
+        storage_mode: str,
+    ) -> LibrarySeriesDTO:
+        """从原始媒体路径新建系列，复制或创建硬链接。"""
+        normalized_mode = _require_storage_mode(storage_mode)
+        series_id = _normalize_series_id(title)
+        if series_id == PLAYGROUND_SERIES_ID:
+            raise ValueError("Playground 请使用单独的“添加 Playground 媒体”入口。")
+        series_dir = self._videos_dir / series_id
+        linked_meta_path = self._workspace_dir / series_id / LINKED_SERIES_META_FILE
+        if series_dir.exists() or linked_meta_path.exists():
+            raise ValueError(f"系列已存在：{series_id}")
+
+        try:
+            series_dir.mkdir(parents=True, exist_ok=False)
+            self._write_series_meta(series_id, title.strip(), storage_mode=normalized_mode)
+            self._import_media_paths(
+                series_dir=series_dir,
+                source_paths=source_paths,
+                storage_mode=normalized_mode,
+            )
             return LibrarySeriesDTO(
                 id=series_id,
                 title=title.strip(),
@@ -680,6 +719,17 @@ class FileSystemVideoWorkspace:
         imported_paths = self._copy_video_streams(series_dir=series_dir, files=files)
         return [self._build_local_video_card(PLAYGROUND_SERIES_ID, path) for path in imported_paths]
 
+    def import_local_playground_videos_from_paths(self, *, source_paths: list[Path]) -> list[LibraryVideoCardDTO]:
+        """从本机路径复制媒体到 Playground；Playground 固定使用复制模式。"""
+        series_dir = self._videos_dir / PLAYGROUND_SERIES_ID
+        series_dir.mkdir(parents=True, exist_ok=True)
+        imported_paths = self._import_media_paths(
+            series_dir=series_dir,
+            source_paths=source_paths,
+            storage_mode="copy",
+        )
+        return [self._build_local_video_card(PLAYGROUND_SERIES_ID, path) for path in imported_paths]
+
     def import_local_series_videos(self, *, series_id: str, files: list[tuple[str, object]]) -> list[LibraryVideoCardDTO]:
         """把媒体追加到既有本地系列；Playground 系列则转交 playground 入口。
 
@@ -697,9 +747,31 @@ class FileSystemVideoWorkspace:
             return self.import_local_playground_videos(files=files)
         if not self._series_exists(series_id):
             raise ValueError(f"系列不存在：{series_id}")
+        if self._read_series_storage_mode(series_id) == "hardlink":
+            raise ValueError("该系列使用硬链接，请通过本机路径选择器添加媒体。")
         series_dir = self._videos_dir / series_id
         series_dir.mkdir(parents=True, exist_ok=True)
         imported_paths = self._copy_video_streams(series_dir=series_dir, files=files)
+        return [self._build_local_video_card(series_id, path) for path in imported_paths]
+
+    def import_local_series_videos_from_paths(
+        self,
+        *,
+        series_id: str,
+        source_paths: list[Path],
+    ) -> list[LibraryVideoCardDTO]:
+        """从本机路径追加媒体，并继承系列存储方式。"""
+        if series_id == PLAYGROUND_SERIES_ID:
+            return self.import_local_playground_videos_from_paths(source_paths=source_paths)
+        if not self._series_exists(series_id):
+            raise ValueError(f"系列不存在：{series_id}")
+        series_dir = self._videos_dir / series_id
+        series_dir.mkdir(parents=True, exist_ok=True)
+        imported_paths = self._import_media_paths(
+            series_dir=series_dir,
+            source_paths=source_paths,
+            storage_mode=self._read_series_storage_mode(series_id),
+        )
         return [self._build_local_video_card(series_id, path) for path in imported_paths]
 
     def _list_videos_for_series(self, series_dir: Path) -> list[LibraryVideoCardDTO]:
@@ -869,6 +941,39 @@ class FileSystemVideoWorkspace:
             copied_paths.append(target_path)
         return copied_paths
 
+    def _import_media_paths(
+        self,
+        *,
+        series_dir: Path,
+        source_paths: list[Path],
+        storage_mode: str,
+    ) -> list[Path]:
+        """将本机媒体路径按系列指定的方式写入目标目录。"""
+        normalized_paths = _normalize_media_paths(source_paths)
+        _validate_media_names(series_dir, [path.name for path in normalized_paths])
+        if storage_mode == "hardlink":
+            target_device = series_dir.stat().st_dev
+            unsupported_paths = [path for path in normalized_paths if path.stat().st_dev != target_device]
+            if unsupported_paths:
+                names = ", ".join(path.name for path in unsupported_paths)
+                raise ValueError(f"无法创建硬链接：媒体文件必须与工作区位于同一磁盘分区：{names}")
+
+        imported_paths: list[Path] = []
+        try:
+            for source_path in normalized_paths:
+                target_path = series_dir / source_path.name
+                if storage_mode == "hardlink":
+                    target_path.hardlink_to(source_path)
+                else:
+                    shutil.copyfile(source_path, target_path)
+                imported_paths.append(target_path)
+        except OSError as error:
+            for imported_path in imported_paths:
+                imported_path.unlink()
+            action = "创建硬链接" if storage_mode == "hardlink" else "复制媒体"
+            raise ValueError(f"{action}失败：{error}") from error
+        return imported_paths
+
     def save_linked_series(self, series: LinkedSeries) -> None:
         """把 linked 系列（含其视频列表）原子写为 `linked_series.json`。"""
         payload = {
@@ -1031,13 +1136,22 @@ class FileSystemVideoWorkspace:
             return None
         return title.strip()
 
-    def _write_series_title(self, series_id: str, title: str) -> None:
-        """把系列标题原子写为 `series_meta.json`，按需创建 series 目录。"""
+    def _read_series_storage_mode(self, series_id: str) -> str:
+        """读取系列存储方式；未标记的历史系列均为复制模式。"""
+        meta_path = self._workspace_dir / series_id / SERIES_META_FILE
+        if not meta_path.exists():
+            return "copy"
+        payload = json.loads(meta_path.read_text(encoding="utf-8"))
+        value = payload.get("storage_mode", "copy")
+        return _require_storage_mode(value)
+
+    def _write_series_meta(self, series_id: str, title: str, *, storage_mode: str) -> None:
+        """原子写入系列标题与不可变的媒体存储方式。"""
         output_dir = self._workspace_dir / series_id
         output_dir.mkdir(parents=True, exist_ok=True)
         atomic_write_text(
             output_dir / SERIES_META_FILE,
-            json.dumps({"title": title}, ensure_ascii=False, indent=2),
+            json.dumps({"title": title, "storage_mode": storage_mode}, ensure_ascii=False, indent=2),
         )
 
     def _get_video_output_dir(self, series_id: str, video_id: str) -> Path:
@@ -1151,6 +1265,41 @@ def _normalize_import_files(files: list[tuple[str, object]]) -> list[tuple[str, 
             raise ValueError(f"不支持的媒体格式：{path.name}")
         normalized.append((path.name, stream))
     return normalized
+
+
+def _normalize_media_paths(source_paths: list[Path]) -> list[Path]:
+    """校验本机媒体路径，确保它们可直接被复制或创建硬链接。"""
+    if not source_paths:
+        raise ValueError("至少选择一个媒体文件。")
+    normalized_paths: list[Path] = []
+    for source_path in source_paths:
+        if not source_path.is_absolute():
+            raise ValueError(f"媒体路径必须为绝对路径：{source_path}")
+        if not source_path.is_file():
+            raise ValueError(f"媒体文件不存在或不是普通文件：{source_path}")
+        if not _is_media_suffix(source_path.suffix):
+            raise ValueError(f"不支持的媒体格式：{source_path.name}")
+        normalized_paths.append(source_path)
+    return normalized_paths
+
+
+def _validate_media_names(series_dir: Path, filenames: list[str]) -> None:
+    """校验媒体名在本批次及目标系列中均不冲突。"""
+    existing_stems = {path.stem for path in series_dir.iterdir() if _is_media_file(path)} if series_dir.exists() else set()
+    incoming_stems = [Path(filename).stem for filename in filenames]
+    duplicate_stems = sorted({stem for stem in incoming_stems if incoming_stems.count(stem) > 1})
+    if duplicate_stems:
+        raise ValueError(f"导入文件存在重复媒体名：{', '.join(duplicate_stems)}")
+    conflicting_stems = sorted(existing_stems.intersection(incoming_stems))
+    if conflicting_stems:
+        raise ValueError(f"目标目录中已存在同名媒体：{', '.join(conflicting_stems)}")
+
+
+def _require_storage_mode(value: object) -> str:
+    """校验本地系列的媒体存储方式。"""
+    if not isinstance(value, str) or value not in STORAGE_MODES:
+        raise ValueError("storage_mode 必须是 copy 或 hardlink。")
+    return value
 
 
 def _is_media_suffix(suffix: str) -> bool:

--- a/src/backend/video_summary/library/ports.py
+++ b/src/backend/video_summary/library/ports.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from pathlib import Path
 from typing import Protocol
 
 from backend.video_summary.generation.ports import ProgressReporter
@@ -166,11 +167,31 @@ class VideoImportStore(Protocol):
     def import_local_series(self, *, title: str, files: list[tuple[str, object]]) -> LibrarySeriesDTO:
         """把一组本地视频导入为一个新系列。"""
 
+    def import_local_series_from_paths(
+        self,
+        *,
+        title: str,
+        source_paths: list[Path],
+        storage_mode: str,
+    ) -> LibrarySeriesDTO:
+        """从本机路径新建系列；媒体以指定存储方式写入工作区。"""
+
     def import_local_playground_videos(self, *, files: list[tuple[str, object]]) -> list[LibraryVideoCardDTO]:
         """把本地视频导入到沙盒演练系列（无需选择系列）。"""
 
+    def import_local_playground_videos_from_paths(self, *, source_paths: list[Path]) -> list[LibraryVideoCardDTO]:
+        """从本机路径把媒体复制到沙盒演练系列。"""
+
     def import_local_series_videos(self, *, series_id: str, files: list[tuple[str, object]]) -> list[LibraryVideoCardDTO]:
         """把本地视频追加到既有系列。"""
+
+    def import_local_series_videos_from_paths(
+        self,
+        *,
+        series_id: str,
+        source_paths: list[Path],
+    ) -> list[LibraryVideoCardDTO]:
+        """从本机路径追加媒体，并继承系列的存储方式。"""
 
 
 class VideoMutationStore(Protocol):

--- a/src/backend/video_summary/library/usecases/imports.py
+++ b/src/backend/video_summary/library/usecases/imports.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from backend.video_summary.library.models import LibrarySeriesDTO, LibraryVideoCardDTO
 from backend.video_summary.library.ports import VideoImportStore
 
@@ -34,6 +36,20 @@ class ImportLocalSeries:
         """
         return self._workspace.import_local_series(title=title, files=files)
 
+    def run_from_paths(
+        self,
+        *,
+        title: str,
+        source_paths: list[Path],
+        storage_mode: str,
+    ) -> LibrarySeriesDTO:
+        """从本机绝对路径创建系列。"""
+        return self._workspace.import_local_series_from_paths(
+            title=title,
+            source_paths=source_paths,
+            storage_mode=storage_mode,
+        )
+
 
 class ImportLocalPlaygroundVideos:
     """把本地视频导入到内置的"沙盒演练"系列中。
@@ -56,6 +72,10 @@ class ImportLocalPlaygroundVideos:
             新加入沙盒系列的视频卡片 DTO 列表。
         """
         return self._workspace.import_local_playground_videos(files=files)
+
+    def run_from_paths(self, *, source_paths: list[Path]) -> list[LibraryVideoCardDTO]:
+        """从本机绝对路径向沙盒追加媒体。"""
+        return self._workspace.import_local_playground_videos_from_paths(source_paths=source_paths)
 
 
 class ImportLocalSeriesVideos:
@@ -80,3 +100,10 @@ class ImportLocalSeriesVideos:
             追加完成后新加入的视频卡片 DTO 列表。
         """
         return self._workspace.import_local_series_videos(series_id=series_id, files=files)
+
+    def run_from_paths(self, *, series_id: str, source_paths: list[Path]) -> list[LibraryVideoCardDTO]:
+        """从本机绝对路径向系列追加媒体。"""
+        return self._workspace.import_local_series_videos_from_paths(
+            series_id=series_id,
+            source_paths=source_paths,
+        )

--- a/src/frontend/src/dev/MotionShowcase.jsx
+++ b/src/frontend/src/dev/MotionShowcase.jsx
@@ -80,7 +80,7 @@ export function MotionShowcase() {
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-3xl font-bold">Framer Motion 动效实验室</h1>
-          <p className="text-stone-500 mt-2">在这里体验原生系统级高级动效，选好感觉后我们再实装到主页面。</p>
+          <p className="text-stone-600 mt-2">在这里体验原生系统级高级动效，选好感觉后我们再实装到主页面。</p>
         </div>
         <button 
           onClick={() => window.location.hash = ""} 
@@ -95,7 +95,7 @@ export function MotionShowcase() {
         {/* 1. Layout Transition (侧边栏收缩重排) */}
         <section className="bg-white p-6 rounded-[2rem] border shadow-sm">
           <h2 className="text-xl font-bold mb-4">1. 无缝布局重排 (Layout Animations)</h2>
-          <p className="text-sm text-stone-500 mb-4">当侧边栏宽度改变时，右侧内容块极其平滑地自动填补空缺，告别闪跳。</p>
+          <p className="text-sm text-stone-600 mb-4">当侧边栏宽度改变时，右侧内容块极其平滑地自动填补空缺，告别闪跳。</p>
           
           <button 
             onClick={() => setSidebarOpen(!isSidebarOpen)}
@@ -108,9 +108,9 @@ export function MotionShowcase() {
             <motion.div 
               layout
               transition={springTransition}
-              className={`${isSidebarOpen ? "w-[120px]" : "w-0"} bg-sky-100 rounded-xl flex items-center justify-center overflow-hidden shrink-0`}
+              className={`${isSidebarOpen ? "w-[120px]" : "w-0"} bg-indigo-100 rounded-xl flex items-center justify-center overflow-hidden shrink-0`}
             >
-              <span className="text-sky-800 font-bold whitespace-nowrap opacity-50">Sidebar</span>
+              <span className="text-indigo-800 font-bold whitespace-nowrap opacity-50">Sidebar</span>
             </motion.div>
             
             <motion.div 
@@ -130,7 +130,7 @@ export function MotionShowcase() {
         {/* 2. Shared Layout Transition (共享元素变形) */}
         <section className="bg-white p-6 rounded-[2rem] border shadow-sm">
           <h2 className="text-xl font-bold mb-4">2. 共享元素变幻 (layoutId)</h2>
-          <p className="text-sm text-stone-500 mb-4">类似 Apple App Store 的卡片展开。卡片脱离文档流直接“飞”成详情页。</p>
+          <p className="text-sm text-stone-600 mb-4">类似 Apple App Store 的卡片展开。卡片脱离文档流直接“飞”成详情页。</p>
           
           <div className="flex gap-4 h-48 relative">
             {cards.map((card) => (
@@ -142,7 +142,7 @@ export function MotionShowcase() {
                 className="flex-1 bg-stone-100 rounded-2xl p-4 cursor-pointer hover:bg-stone-200"
               >
                 <motion.h3 layoutId={`card-title-${card.id}`} className="font-bold text-lg">{card.title}</motion.h3>
-                <p className="text-xs text-stone-500 mt-2">{card.desc}</p>
+                <p className="text-xs text-stone-600 mt-2">{card.desc}</p>
               </motion.div>
             ))}
 
@@ -176,9 +176,9 @@ export function MotionShowcase() {
         <section className="bg-white p-6 rounded-[2rem] border shadow-sm">
           <div className="flex justify-between items-center mb-4">
              <h2 className="text-xl font-bold">3. 彻底告别生硬销毁 (Exit Animation)</h2>
-             <button onClick={resetMessages} className="text-sm text-sky-600 font-semibold hover:underline">Reset</button>
+             <button onClick={resetMessages} className="text-sm text-indigo-600 font-semibold hover:underline">Reset</button>
           </div>
-          <p className="text-sm text-stone-500 mb-4">点击列表项删除。你甚至能看到剩余的元素优雅地上移填补空缺。</p>
+          <p className="text-sm text-stone-600 mb-4">点击列表项删除。你甚至能看到剩余的元素优雅地上移填补空缺。</p>
           
           <ul className="flex flex-col gap-2">
             <AnimatePresence mode="popLayout">
@@ -203,7 +203,7 @@ export function MotionShowcase() {
         {/* 4. Drag and Constraints (物理拖拽缓冲) */}
         <section className="bg-white p-6 rounded-[2rem] border shadow-sm overflow-hidden overflow-visible">
           <h2 className="text-xl font-bold mb-4">4. 极度真实的拖拽惯性 (Drag Physics)</h2>
-          <p className="text-sm text-stone-500 mb-4">非常适合思维导图画板的交互。试着在这个方框内用力甩动圆形节点，感受回弹停滞！</p>
+          <p className="text-sm text-stone-600 mb-4">非常适合思维导图画板的交互。试着在这个方框内用力甩动圆形节点，感受回弹停滞！</p>
           
           <motion.div className="h-48 bg-stone-100 rounded-2xl border-2 border-stone-200 border-dashed relative overflow-hidden flex items-center justify-center p-4">
              <motion.div
@@ -222,12 +222,12 @@ export function MotionShowcase() {
         {/* 5. Peer-to-Peer Switch (同级平滑切换) */}
         <section className="bg-white p-6 rounded-[2rem] border shadow-sm lg:col-span-2">
           <h2 className="text-xl font-bold mb-2">5. 同级平滑切换 (Peer-to-Peer Switch)</h2>
-          <p className="text-sm text-stone-500 mb-6">这就是我们刚刚讨论的场景：在工作区左侧栏切换不同视频时，右侧主体内容的无缝过渡。</p>
+          <p className="text-sm text-stone-600 mb-6">这就是我们刚刚讨论的场景：在工作区左侧栏切换不同视频时，右侧主体内容的无缝过渡。</p>
           
           <div className="flex gap-4 mb-6">
             <span className="text-sm font-bold text-stone-700 flex items-center mr-2">选择动效风格:</span>
             {["fade", "slide", "blur"].map(effect => (
-              <label key={effect} className="flex flex-row items-center gap-2 text-sm cursor-pointer hover:text-sky-600">
+              <label key={effect} className="flex flex-row items-center gap-2 text-sm cursor-pointer hover:text-indigo-600">
                 <input type="radio" name="effect" checked={switchEffect === effect} onChange={() => setSwitchEffect(effect)} />
                 <span className="uppercase font-mono">{effect}</span>
               </label>
@@ -237,12 +237,12 @@ export function MotionShowcase() {
           <div className="flex flex-col md:flex-row h-72 rounded-2xl border overflow-hidden bg-stone-50">
             {/* Mock Sidebar */}
             <div className="w-full md:w-64 bg-stone-100 border-b md:border-b-0 md:border-r border-stone-200 p-4 flex flex-col gap-2 shrink-0">
-              <span className="text-xs font-bold text-stone-500 tracking-widest pl-2 mb-2">VIDEOS LIST</span>
+              <span className="text-xs font-bold text-stone-600 tracking-widest pl-2 mb-2">VIDEOS LIST</span>
               {["1-4 准备工作", "1-5 安装 Nacos", "1-6 仿 Manus 框架"].map(tab => (
                 <button 
                   key={tab} 
                   onClick={() => setSwitchTab(tab)}
-                  className={`text-left px-4 py-3 rounded-xl text-sm font-semibold transition-all ${switchTab === tab ? "bg-white shadow-sm border border-stone-200 text-sky-600" : "text-stone-600 hover:bg-stone-200/50"}`}
+                  className={`text-left px-4 py-3 rounded-xl text-sm font-semibold transition-all ${switchTab === tab ? "bg-white shadow-sm border border-stone-200 text-indigo-600" : "text-stone-600 hover:bg-stone-200/50"}`}
                 >
                   {tab}
                 </button>
@@ -263,7 +263,7 @@ export function MotionShowcase() {
                  >
                    <div className="w-16 h-16 rounded-full bg-stone-200 mx-auto mb-4" />
                    <h3 className="text-2xl font-bold text-stone-800 mb-2">{switchTab}</h3>
-                   <p className="text-stone-500 text-sm">这里是当前视频的详细信息、AI 总结内容等。感受 {switchEffect.toUpperCase()} 退场和进场时的优雅交接。</p>
+                   <p className="text-stone-600 text-sm">这里是当前视频的详细信息、AI 总结内容等。感受 {switchEffect.toUpperCase()} 退场和进场时的优雅交接。</p>
                  </motion.div>
                </AnimatePresence>
             </div>
@@ -273,7 +273,7 @@ export function MotionShowcase() {
         {/* 6. Active Indicator Slide (平滑选中框过渡) */}
         <section className="bg-white p-6 rounded-[2rem] border shadow-sm">
           <h2 className="text-xl font-bold mb-4">6. 平滑选中框过渡 (Active Indicator)</h2>
-          <p className="text-sm text-stone-500 mb-6">点击任意项目。你想要的选中框“不仅是变色，而是丝滑滑过去”的神级效果。</p>
+          <p className="text-sm text-stone-600 mb-6">点击任意项目。你想要的选中框“不仅是变色，而是丝滑滑过去”的神级效果。</p>
           
           <div className="flex flex-col gap-1 w-full max-w-xs bg-stone-100 p-2 rounded-2xl relative">
             {menus.map((menu) => {
@@ -283,7 +283,7 @@ export function MotionShowcase() {
                   key={menu}
                   onClick={() => setActiveMenu(menu)}
                   className={`relative w-full text-left px-4 py-3 rounded-xl text-sm font-bold transition-colors duration-200 z-10 ${
-                    isActive ? "text-sky-900" : "text-stone-500 hover:text-stone-800"
+                    isActive ? "text-indigo-900" : "text-stone-600 hover:text-stone-800"
                   }`}
                 >
                   {/* The secret sauce: An absolutely positioned background with layoutId */}
@@ -314,7 +314,7 @@ export function MotionShowcase() {
                 </button>
              </div>
           </div>
-          <p className="text-sm text-stone-500 mb-6">具有方向感知（向左翻左入，向右翻右入），经常用在全屏图库或章节阅读里。</p>
+          <p className="text-sm text-stone-600 mb-6">具有方向感知（向左翻左入，向右翻右入），经常用在全屏图库或章节阅读里。</p>
 
           <div className="relative h-48 w-full flex items-center justify-center bg-stone-50 rounded-2xl border overflow-hidden">
             <AnimatePresence custom={direction} mode="popLayout">

--- a/src/frontend/src/features/workspace/model/useWorkspaceController.js
+++ b/src/frontend/src/features/workspace/model/useWorkspaceController.js
@@ -246,6 +246,7 @@ export function useWorkspaceController() {
     onOpenChatDrawer,
     onCloseChatDrawer,
     onResolveLinkedSeries: contentActions.onResolveLinkedSeries,
+    onSelectLocalMedia: contentActions.onSelectLocalMedia,
     onResolvePlaygroundVideo: contentActions.onResolvePlaygroundVideo,
     onResolveSeriesVideo: contentActions.onResolveSeriesVideo,
     onInitBilibiliCookie: contentActions.onInitBilibiliCookie,

--- a/src/frontend/src/features/workspace/model/workspaceApi.js
+++ b/src/frontend/src/features/workspace/model/workspaceApi.js
@@ -766,15 +766,28 @@ function buildRecoveredMeta(role, createdAt) {
   return `${actor} • ${suffix}`;
 }
 
-export async function importLocalSeries(seriesTitle, files) {
-  const payload = new FormData();
-  payload.append("series_title", seriesTitle);
-  for (const file of files) {
-    payload.append("files", file);
-  }
-  return fetchJson("/api/import/local/series", {
+export async function selectLocalMedia() {
+  const payload = await fetchJson("/api/import/local/select", {
     method: "POST",
-    body: payload,
+  });
+  const sourcePaths = Array.isArray(payload.source_paths)
+    ? payload.source_paths.filter((path) => typeof path === "string" && path)
+    : [];
+  return {
+    sourcePaths,
+    hardlinkAvailable: payload.hardlink_available !== false,
+  };
+}
+
+export async function importLocalSeries(seriesTitle, sourcePaths, storageMode) {
+  return fetchJson("/api/import/local/series/from-paths", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      series_title: seriesTitle,
+      source_paths: sourcePaths,
+      storage_mode: storageMode,
+    }),
   });
 }
 
@@ -864,25 +877,19 @@ export function subscribeChaoxingImportProgress(taskId, listener) {
   );
 }
 
-export async function importLocalPlaygroundVideos(files) {
-  const payload = new FormData();
-  for (const file of files) {
-    payload.append("files", file);
-  }
-  return fetchJson("/api/import/local/playground", {
+export async function importLocalPlaygroundVideos(sourcePaths) {
+  return fetchJson("/api/import/local/playground/from-paths", {
     method: "POST",
-    body: payload,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source_paths: sourcePaths }),
   });
 }
 
-export async function importLocalSeriesVideos(seriesId, files) {
-  const payload = new FormData();
-  for (const file of files) {
-    payload.append("files", file);
-  }
-  return fetchJson(`/api/import/local/series/${encodeURIComponent(seriesId)}`, {
+export async function importLocalSeriesVideos(seriesId, sourcePaths) {
+  return fetchJson(`/api/import/local/series/${encodeURIComponent(seriesId)}/from-paths`, {
     method: "POST",
-    body: payload,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source_paths: sourcePaths }),
   });
 }
 

--- a/src/frontend/src/features/workspace/model/workspaceContentActions.js
+++ b/src/frontend/src/features/workspace/model/workspaceContentActions.js
@@ -24,6 +24,7 @@ import {
   loadChaoxingStatus,
   resolveBilibiliSeries,
   resolveBilibiliVideo,
+  selectLocalMedia,
   subscribeChaoxingImportProgress,
   startVideoDownload,
   subscribeMindmapGenerationProgress,
@@ -629,9 +630,18 @@ export function createWorkspaceContentActions({ state, dispatch, selectedVideo }
     }
   }
 
-  async function onImportLocalSeries(seriesTitle, files) {
+  async function onSelectLocalMedia() {
     try {
-      const rawSeries = await importLocalSeries(seriesTitle, files);
+      return await selectLocalMedia();
+    } catch (error) {
+      dispatch({ type: "load_failed", message: error instanceof Error ? error.message : "选择本机媒体失败" });
+      throw error;
+    }
+  }
+
+  async function onImportLocalSeries(seriesTitle, sourcePaths, storageMode) {
+    try {
+      const rawSeries = await importLocalSeries(seriesTitle, sourcePaths, storageMode);
       await reloadWorkspaceLibrary();
       return rawSeries;
     } catch (error) {
@@ -792,9 +802,9 @@ export function createWorkspaceContentActions({ state, dispatch, selectedVideo }
     }
   }
 
-  async function onImportLocalPlaygroundVideos(files) {
+  async function onImportLocalPlaygroundVideos(sourcePaths) {
     try {
-      const rawVideos = await importLocalPlaygroundVideos(files);
+      const rawVideos = await importLocalPlaygroundVideos(sourcePaths);
       await reloadWorkspaceLibrary();
       return rawVideos;
     } catch (error) {
@@ -803,9 +813,9 @@ export function createWorkspaceContentActions({ state, dispatch, selectedVideo }
     }
   }
 
-  async function onImportSeriesVideos(seriesId, files) {
+  async function onImportSeriesVideos(seriesId, sourcePaths) {
     try {
-      const rawVideos = await importLocalSeriesVideos(seriesId, files);
+      const rawVideos = await importLocalSeriesVideos(seriesId, sourcePaths);
       await reloadWorkspaceLibrary();
       return rawVideos;
     } catch (error) {
@@ -867,6 +877,7 @@ export function createWorkspaceContentActions({ state, dispatch, selectedVideo }
     onUpdateNote,
     onDeleteNote,
     onResolveLinkedSeries,
+    onSelectLocalMedia,
     onResolvePlaygroundVideo,
     onResolveSeriesVideo,
     onInitBilibiliCookie,

--- a/src/frontend/src/features/workspace/ui/ChatDrawer.jsx
+++ b/src/frontend/src/features/workspace/ui/ChatDrawer.jsx
@@ -45,7 +45,7 @@ export function ChatDrawer({ isOpen, onClose, ...chatPanelProps }) {
                 type="button"
                 onClick={onClose}
                 aria-label="关闭对话"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-full text-stone-500 transition-colors hover:bg-stone-100 dark:text-stone-400 dark:hover:bg-stone-800"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-full text-stone-600 transition-colors hover:bg-stone-100 dark:text-stone-400 dark:hover:bg-stone-800"
               >
                 <X size={16} />
               </button>

--- a/src/frontend/src/features/workspace/ui/MindmapCanvas.jsx
+++ b/src/frontend/src/features/workspace/ui/MindmapCanvas.jsx
@@ -81,7 +81,7 @@ export function MindmapCanvas({ root, selectedNodeId, onSelectNode, markmapRef }
 
   if (!root) {
     return (
-      <div className="p-8 text-stone-500 text-sm text-center">
+      <div className="p-8 text-stone-600 text-sm text-center">
         当前没有导图数据。
       </div>
     );

--- a/src/frontend/src/features/workspace/ui/WorkspaceChatPanel.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceChatPanel.jsx
@@ -138,7 +138,7 @@ export function WorkspaceChatPanel({
                 {currentPageLabel}
               </span>
             </div>
-            <p className="text-xs text-stone-500 dark:text-stone-400">基于《{scopeLabel}》</p>
+            <p className="text-xs text-stone-600 dark:text-stone-400">基于《{scopeLabel}》</p>
           </div>
         </div>
         <WorkspaceContextUsageInline usage={contextUsage} loading={contextUsageLoading} />
@@ -196,7 +196,7 @@ export function WorkspaceChatPanel({
               <Sparkles size={28} className="text-accent" />
             </div>
             <h2 className="text-xl font-bold text-stone-800 dark:text-stone-100 mb-2">有什么我可以帮您的？</h2>
-            <p className="text-sm text-stone-500 dark:text-stone-400 mb-10 max-w-md text-center">您可以直接提问，或者尝试以下快速指令来探索当前上下文。</p>
+            <p className="text-sm text-stone-600 dark:text-stone-400 mb-10 max-w-md text-center">您可以直接提问，或者尝试以下快速指令来探索当前上下文。</p>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3 w-full max-w-2xl">
               {suggestedPrompts.map((prompt, idx) => {
@@ -213,7 +213,7 @@ export function WorkspaceChatPanel({
                       <Icon size={16} />
                       {prompt.title}
                     </div>
-                    <div className="text-xs text-stone-500 dark:text-stone-400 font-medium leading-relaxed">
+                    <div className="text-xs text-stone-600 dark:text-stone-400 font-medium leading-relaxed">
                       {prompt.desc}
                     </div>
                   </button>
@@ -250,13 +250,13 @@ export function WorkspaceChatPanel({
                 >
                   {renderMessageContent(message, isAssistant)}
                 </div>
-                <div className={`flex items-center gap-2 text-xs text-stone-400 dark:text-stone-500 ${isAssistant ? "ml-1" : ""}`}>
+                <div className={`flex items-center gap-2 text-xs text-stone-500 dark:text-stone-500 ${isAssistant ? "ml-1" : ""}`}>
                   <span>{message.meta}</span>
                   {canCopy ? (
                     <CopyToClipboardButton
                       text={message.content}
                       iconSize={12}
-                      className="gap-1 rounded-full bg-transparent px-2 py-0.5 font-medium text-stone-400 hover:bg-stone-100 hover:text-stone-700 dark:bg-transparent dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
+                      className="gap-1 rounded-full bg-transparent px-2 py-0.5 font-medium text-stone-500 hover:bg-stone-100 hover:text-stone-700 dark:bg-transparent dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
                     />
                   ) : null}
                 </div>
@@ -315,8 +315,8 @@ export function WorkspaceChatPanel({
           </div>
         </div>
         <div className="flex items-center justify-center gap-2 mt-4 opacity-70">
-          <Sparkles size={12} className="text-stone-400 dark:text-stone-500" />
-          <p className="text-xs font-medium text-stone-400 dark:text-stone-500">
+          <Sparkles size={12} className="text-stone-500 dark:text-stone-500" />
+          <p className="text-xs font-medium text-stone-500 dark:text-stone-500">
             {chatLocked
               ? "概况生成完成后，这里会恢复正常提问"
               : seriesRagLocked
@@ -359,9 +359,9 @@ function WorkspaceContextUsageInline({ usage, loading }) {
         <div className="rounded-2xl border border-stone-200/80 bg-white/95 p-4 shadow-xl backdrop-blur-lg dark:border-stone-700 dark:bg-stone-900/95">
           <div className="flex items-center justify-between mb-2">
             <strong className="text-xs font-semibold text-stone-700 dark:text-stone-200">上下文预算</strong>
-            <span className="text-xs text-stone-500 dark:text-stone-400">剩余 {formatTokenCount(usage.remainingTokens)}</span>
+            <span className="text-xs text-stone-600 dark:text-stone-400">剩余 {formatTokenCount(usage.remainingTokens)}</span>
           </div>
-          <p className="text-[11px] text-stone-500 dark:text-stone-400 mb-3">
+          <p className="text-[11px] text-stone-600 dark:text-stone-400 mb-3">
             已估算 {usageLabel}，保留输出 {formatTokenCount(usage.reservedOutputTokens)}
           </p>
           <div className="h-1.5 overflow-hidden rounded-full bg-stone-200/80 dark:bg-stone-800 mb-3">
@@ -404,7 +404,7 @@ function WorkspaceToolTraceMessage({ message }) {
             <div className="flex flex-wrap items-center gap-2">
               <strong className="text-[15px] font-semibold">{message.content}</strong>
               {durationLabel ? (
-                <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-500 dark:bg-stone-800 dark:text-stone-400">
+                <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600 dark:bg-stone-800 dark:text-stone-400">
                   <Clock3 size={12} />
                   用时 {durationLabel}
                 </span>
@@ -420,7 +420,7 @@ function WorkspaceToolTraceMessage({ message }) {
                 </span>
               ) : null}
             </div>
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-stone-600 dark:text-stone-400">
               {isRunning
                 ? "工具正在执行中"
                 : isFailed
@@ -430,7 +430,7 @@ function WorkspaceToolTraceMessage({ message }) {
                     : "展开查看本轮实际调用的工具名和步骤说明"}
             </p>
           </div>
-          <ChevronRight size={18} className="shrink-0 text-stone-400 transition-transform group-open:rotate-90" />
+          <ChevronRight size={18} className="shrink-0 text-stone-500 transition-transform group-open:rotate-90" />
         </div>
       </summary>
 
@@ -455,10 +455,10 @@ function WorkspaceToolTraceMessage({ message }) {
                   {step.status === "running" ? "进行中" : step.status === "failed" ? "失败" : "已完成"}
                 </span>
                 {step.target ? (
-                  <span className="truncate text-xs text-stone-500 dark:text-stone-400">({step.target})</span>
+                  <span className="truncate text-xs text-stone-600 dark:text-stone-400">({step.target})</span>
                 ) : null}
                 {shouldShowDuration(step.durationMs) ? (
-                  <span className="text-xs text-stone-400 dark:text-stone-500">用时 {formatDurationLabel(step.durationMs)}</span>
+                  <span className="text-xs text-stone-500 dark:text-stone-500">用时 {formatDurationLabel(step.durationMs)}</span>
                 ) : null}
               </div>
             </div>
@@ -487,17 +487,17 @@ function WorkspaceSeekReferenceMessage({ message, onOpenSeekReference }) {
             <div className="flex flex-wrap items-center gap-2">
               <strong className="text-[15px] font-semibold">{title}</strong>
             </div>
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-stone-600 dark:text-stone-400">
               展开查看命中的转写片段，再决定是否跳到视频。
             </p>
           </div>
-          <ChevronRight size={18} className="shrink-0 text-stone-400 transition-transform group-open:rotate-90" />
+          <ChevronRight size={18} className="shrink-0 text-stone-500 transition-transform group-open:rotate-90" />
         </div>
       </summary>
 
       <div className="border-t border-info/20 px-4 py-4 dark:border-info/10">
         {reference.query ? (
-          <p className="text-xs font-medium text-stone-500 dark:text-stone-400">
+          <p className="text-xs font-medium text-stone-600 dark:text-stone-400">
             检索问题：{reference.query}
           </p>
         ) : null}
@@ -546,17 +546,17 @@ function WorkspaceThoughtTraceMessage({ message }) {
               <div className="flex flex-wrap items-center gap-2">
                 <strong className="text-[15px] font-semibold">{message.content}</strong>
                 {durationLabel ? (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-500 dark:bg-stone-800 dark:text-stone-400">
+                  <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600 dark:bg-stone-800 dark:text-stone-400">
                     <Clock3 size={12} />
                     用时 {durationLabel}
                   </span>
                 ) : null}
               </div>
-              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-1 text-xs text-stone-600 dark:text-stone-400">
                 {isRunning ? "当前按图节点顺序执行中" : isFailed ? "本轮图节点执行失败" : "本轮图节点执行已完成"}
               </p>
             </div>
-            <ChevronRight size={18} className="shrink-0 text-stone-400 transition-transform group-open:rotate-90" />
+            <ChevronRight size={18} className="shrink-0 text-stone-500 transition-transform group-open:rotate-90" />
           </div>
         </summary>
 
@@ -588,7 +588,7 @@ function WorkspaceThoughtTraceMessage({ message }) {
                         </div>
                         <div className="min-w-0">
                           <div className="text-sm font-semibold text-stone-800 dark:text-stone-100">{stage.label}</div>
-                          <div className="mt-0.5 text-xs text-stone-500 dark:text-stone-400">{stage.nodeId}</div>
+                          <div className="mt-0.5 text-xs text-stone-600 dark:text-stone-400">{stage.nodeId}</div>
                         </div>
                       </div>
                       <div className="flex shrink-0 items-center gap-2">
@@ -601,7 +601,7 @@ function WorkspaceThoughtTraceMessage({ message }) {
                           {stageRunning ? "执行中" : stageFailed ? "失败" : "已完成"}
                         </span>
                         {stageDurationLabel ? (
-                          <span className="text-xs text-stone-400 dark:text-stone-500">用时 {stageDurationLabel}</span>
+                          <span className="text-xs text-stone-500 dark:text-stone-500">用时 {stageDurationLabel}</span>
                         ) : null}
                       </div>
                     </div>
@@ -626,17 +626,17 @@ function WorkspaceThoughtTraceMessage({ message }) {
             <div className="flex flex-wrap items-center gap-2">
               <strong className="text-[15px] font-semibold">{message.content}</strong>
               {durationLabel ? (
-                <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-500 dark:bg-stone-800 dark:text-stone-400">
+                <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600 dark:bg-stone-800 dark:text-stone-400">
                   <Clock3 size={12} />
                   用时 {durationLabel}
                 </span>
               ) : null}
             </div>
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-stone-600 dark:text-stone-400">
               {isRunning ? "正在分析当前问题与上下文，思路会实时展开" : isFailed ? "本轮思路执行失败，展开查看错误摘要" : "展开查看本轮对问题的思路摘要"}
             </p>
           </div>
-          <ChevronRight size={18} className="shrink-0 text-stone-400 transition-transform group-open:rotate-90" />
+          <ChevronRight size={18} className="shrink-0 text-stone-500 transition-transform group-open:rotate-90" />
         </div>
       </summary>
 

--- a/src/frontend/src/features/workspace/ui/WorkspaceGenerationOverlay.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceGenerationOverlay.jsx
@@ -64,7 +64,7 @@ export function WorkspaceGenerationOverlay({
         <LoaderCircle size={36} className="animate-spin text-accent" strokeWidth={2.5} />
         <div className="w-full">
           <h3 className="mb-1.5 text-base font-bold text-stone-900 dark:text-stone-100">{title}</h3>
-          <p className="mb-2 text-[13px] font-medium text-stone-500 dark:text-stone-400">
+          <p className="mb-2 text-[13px] font-medium text-stone-600 dark:text-stone-400">
             {generationSnapshot?.detail ?? "正在阅读视频并提炼核心内容..."}
           </p>
           <p className="mb-3 text-xs font-bold text-accent">
@@ -88,9 +88,9 @@ export function WorkspaceGenerationOverlay({
             )}
           </div>
           <div className="mt-4 grid grid-cols-3 gap-2 text-left">
-            <WorkspaceMetricCard label="已耗时" value={elapsedLabel} className="rounded-2xl px-3 py-2" labelClassName="text-[10px] text-stone-400 dark:text-stone-500" valueClassName="mt-1 text-sm" />
-            <WorkspaceMetricCard label="预计总时长" value={estimatedTotalLabel} className="rounded-2xl px-3 py-2" labelClassName="text-[10px] text-stone-400 dark:text-stone-500" valueClassName="mt-1 text-sm" />
-            <WorkspaceMetricCard label="预计剩余" value={remainingLabel} className="rounded-2xl px-3 py-2" labelClassName="text-[10px] text-stone-400 dark:text-stone-500" valueClassName="mt-1 text-sm" />
+            <WorkspaceMetricCard label="已耗时" value={elapsedLabel} className="rounded-2xl px-3 py-2" labelClassName="text-[10px] text-stone-500 dark:text-stone-500" valueClassName="mt-1 text-sm" />
+            <WorkspaceMetricCard label="预计总时长" value={estimatedTotalLabel} className="rounded-2xl px-3 py-2" labelClassName="text-[10px] text-stone-500 dark:text-stone-500" valueClassName="mt-1 text-sm" />
+            <WorkspaceMetricCard label="预计剩余" value={remainingLabel} className="rounded-2xl px-3 py-2" labelClassName="text-[10px] text-stone-500 dark:text-stone-500" valueClassName="mt-1 text-sm" />
           </div>
           <div className="mt-4 flex flex-col gap-2">
             {GENERATION_STAGE_ITEMS.filter((item) => item.id !== "completed" || generationSnapshot?.status === "completed").map((item) => {
@@ -110,7 +110,7 @@ export function WorkspaceGenerationOverlay({
                   }`}
                 >
                   <span className="text-xs font-medium text-stone-700 dark:text-stone-300">{item.label}</span>
-                  <span className="text-[11px] font-semibold text-stone-400 dark:text-stone-500">
+                  <span className="text-[11px] font-semibold text-stone-500 dark:text-stone-500">
                     {isCurrent ? "进行中" : isDone ? "已完成" : "等待中"}
                   </span>
                 </div>

--- a/src/frontend/src/features/workspace/ui/WorkspaceImportModal.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceImportModal.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { X, Loader2, CheckCircle2, AlertCircle, FolderUp, Film, Search } from "lucide-react";
+import { X, Loader2, CheckCircle2, AlertCircle, FolderUp, Film, Search, Copy, Link2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 
 export function WorkspaceImportModal({
@@ -16,6 +16,7 @@ export function WorkspaceImportModal({
   onCancelChaoxingImport,
   onLoadChaoxingCourses,
   onImportChaoxingCourse,
+  onSelectLocalMedia,
   onImportLocalSeries,
   onImportSeriesVideos,
   onImportLocalPlaygroundVideos,
@@ -24,7 +25,9 @@ export function WorkspaceImportModal({
   const [externalProvider, setExternalProvider] = useState("bilibili");
   const [url, setUrl] = useState("");
   const [seriesTitle, setSeriesTitle] = useState("");
-  const [files, setFiles] = useState([]);
+  const [sourcePaths, setSourcePaths] = useState([]);
+  const [storageMode, setStorageMode] = useState("copy");
+  const [hardlinkAvailable, setHardlinkAvailable] = useState(true);
   const [status, setStatus] = useState("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const [preview, setPreview] = useState(null);
@@ -68,14 +71,14 @@ export function WorkspaceImportModal({
     });
   }, [chaoxingCourses, normalizedChaoxingCourseSearch]);
   const selectedFileSummary = useMemo(() => {
-    if (!files.length) {
+    if (!sourcePaths.length) {
       return "未选择文件";
     }
-    if (files.length === 1) {
-      return files[0].name;
+    if (sourcePaths.length === 1) {
+      return sourcePaths[0].split(/[\\/]/).pop() || sourcePaths[0];
     }
-    return `已选择 ${files.length} 个文件`;
-  }, [files]);
+    return `已选择 ${sourcePaths.length} 个文件`;
+  }, [sourcePaths]);
 
   useEffect(() => {
     loadChaoxingStatusRef.current = onLoadChaoxingStatus;
@@ -231,6 +234,30 @@ export function WorkspaceImportModal({
     onClose();
   }
 
+  async function handleSelectLocalMedia() {
+    if (!onSelectLocalMedia) {
+      return;
+    }
+    setStatus("selecting");
+    setErrorMsg("");
+    try {
+      const selection = await onSelectLocalMedia();
+      if (mountedRef.current) {
+        setSourcePaths(selection.sourcePaths);
+        setHardlinkAvailable(selection.hardlinkAvailable);
+        if (!selection.hardlinkAvailable && storageMode === "hardlink") {
+          setStorageMode("copy");
+        }
+        setStatus("idle");
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        setStatus("error");
+        setErrorMsg(error instanceof Error ? error.message : "选择媒体文件失败");
+      }
+    }
+  }
+
   async function handleSubmit() {
     setStatus("loading");
     setErrorMsg("");
@@ -262,19 +289,19 @@ export function WorkspaceImportModal({
             : await onResolveVideo(trimmed, isSeriesVideo ? targetSeriesId : null);
         }
       } else {
-        if (!files.length) {
+        if (!sourcePaths.length) {
           setStatus("idle");
           return;
         }
         result = isSeriesCreation
-          ? await onImportLocalSeries(seriesTitle.trim(), files)
+          ? await onImportLocalSeries(seriesTitle.trim(), sourcePaths, storageMode)
           : isSeriesVideo
-            ? await onImportSeriesVideos(targetSeriesId, files)
-            : await onImportLocalPlaygroundVideos(files);
+            ? await onImportSeriesVideos(targetSeriesId, sourcePaths)
+            : await onImportLocalPlaygroundVideos(sourcePaths);
       }
       setPreview({
         title: isSeriesCreation ? result.title : (isSeriesVideo ? (targetSeriesTitle || "当前系列") : result.title ?? "Playground"),
-        videoCount: Array.isArray(result) ? result.length : result.videos?.length ?? (sourceType === "external" ? 1 : files.length),
+        videoCount: Array.isArray(result) ? result.length : result.videos?.length ?? (sourceType === "external" ? 1 : sourcePaths.length),
       });
       setStatus("success");
     } catch (error) {
@@ -284,10 +311,10 @@ export function WorkspaceImportModal({
     }
   }
 
-  const submitDisabled = status === "loading" || (
+  const submitDisabled = status === "loading" || status === "selecting" || (
     sourceType === "external"
       ? (externalProvider === "chaoxing" ? !selectedChaoxingCourseKey || !chaoxingStatus?.initialized : !url.trim())
-      : (isSeriesCreation ? !seriesTitle.trim() || !files.length : !files.length)
+      : (isSeriesCreation ? !seriesTitle.trim() || !sourcePaths.length : !sourcePaths.length)
   );
 
   return (
@@ -316,14 +343,14 @@ export function WorkspaceImportModal({
                 <FolderUp size={18} />
               </div>
               <div>
-                <p className="mb-0.5 text-[10px] font-bold uppercase tracking-widest text-stone-500 dark:text-zinc-500">{subtitle}</p>
+                <p className="mb-0.5 text-[10px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-500">{subtitle}</p>
                 <h2 className="text-base font-bold leading-tight text-stone-900 dark:text-stone-100">{title}</h2>
               </div>
             </div>
             <button
               type="button"
               onClick={handleClose}
-              className="flex h-8 w-8 items-center justify-center rounded-full text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600 dark:hover:bg-neutral-800 dark:hover:text-stone-200"
+              className="flex h-8 w-8 items-center justify-center rounded-full text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-600 dark:hover:bg-neutral-800 dark:hover:text-stone-200"
             >
               <X size={18} />
             </button>
@@ -334,11 +361,10 @@ export function WorkspaceImportModal({
               <button
                 type="button"
                 onClick={() => setSourceType("local")}
-                className={`cursor-pointer rounded-2xl border px-4 py-3 text-left text-sm font-bold transition-colors ${
-                  sourceType === "local"
+                className={`cursor-pointer rounded-2xl border px-4 py-3 text-left text-sm font-bold transition-colors ${sourceType === "local"
                     ? "border-accent bg-accent/10 text-accent"
                     : "border-stone-200 bg-white text-stone-600 dark:border-stone-700 dark:bg-neutral-900 dark:text-zinc-300"
-                }`}
+                  }`}
               >
                 本地媒体
                 <p className="mt-1 text-xs font-medium opacity-70">复制文件到 videos 目录。</p>
@@ -346,11 +372,10 @@ export function WorkspaceImportModal({
               <button
                 type="button"
                 onClick={() => setSourceType("external")}
-                className={`cursor-pointer rounded-2xl border px-4 py-3 text-left text-sm font-bold transition-colors ${
-                  sourceType === "external"
+                className={`cursor-pointer rounded-2xl border px-4 py-3 text-left text-sm font-bold transition-colors ${sourceType === "external"
                     ? "border-accent bg-accent/10 text-accent"
                     : "border-stone-200 bg-white text-stone-600 dark:border-stone-700 dark:bg-neutral-900 dark:text-zinc-300"
-                }`}
+                  }`}
               >
                 外部来源
                 <p className="mt-1 text-xs font-medium opacity-70">外部API下载</p>
@@ -362,65 +387,63 @@ export function WorkspaceImportModal({
                 <div>
                   <p className="mb-2 text-xs font-bold tracking-wide text-stone-600 dark:text-zinc-400">渠道</p>
                   <div className="inline-flex rounded-2xl border border-stone-200 bg-stone-100 p-1 dark:border-stone-700 dark:bg-neutral-900">
-                  <button
-                    type="button"
-                    onClick={() => setExternalProvider("bilibili")}
-                    className={`cursor-pointer rounded-xl px-3.5 py-2 text-xs font-bold transition-colors ${
-                      externalProvider === "bilibili"
-                        ? "bg-white text-accent shadow-sm dark:bg-neutral-800"
-                        : "text-stone-500 hover:text-stone-800 dark:text-zinc-400 dark:hover:text-zinc-100"
-                    }`}
-                  >
-                    Bilibili
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setExternalProvider("chaoxing")}
-                    className={`cursor-pointer rounded-xl px-3.5 py-2 text-xs font-bold transition-colors ${
-                      externalProvider === "chaoxing"
-                        ? "bg-white text-accent shadow-sm dark:bg-neutral-800"
-                        : "text-stone-500 hover:text-stone-800 dark:text-zinc-400 dark:hover:text-zinc-100"
-                    }`}
-                  >
-                    ChaoXing
-                  </button>
+                    <button
+                      type="button"
+                      onClick={() => setExternalProvider("bilibili")}
+                      className={`cursor-pointer rounded-xl px-3.5 py-2 text-xs font-bold transition-colors ${externalProvider === "bilibili"
+                          ? "bg-white text-accent shadow-sm dark:bg-neutral-800"
+                          : "text-stone-600 hover:text-stone-800 dark:text-zinc-400 dark:hover:text-zinc-100"
+                        }`}
+                    >
+                      Bilibili
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setExternalProvider("chaoxing")}
+                      className={`cursor-pointer rounded-xl px-3.5 py-2 text-xs font-bold transition-colors ${externalProvider === "chaoxing"
+                          ? "bg-white text-accent shadow-sm dark:bg-neutral-800"
+                          : "text-stone-600 hover:text-stone-800 dark:text-zinc-400 dark:hover:text-zinc-100"
+                        }`}
+                    >
+                      ChaoXing
+                    </button>
                   </div>
                 </div>
                 {externalProvider === "bilibili" ? (
-                <>
-                <label className="mb-2 block text-xs font-bold tracking-wide text-stone-600 dark:text-zinc-400">
-                  {isSeriesCreation ? "Bilibili 系列 / 多 P URL" : "Bilibili 视频 URL"}
-                </label>
-                <input
-                  type="url"
-                  value={url}
-                  onChange={(event) => setUrl(event.target.value)}
-                  placeholder={isSeriesCreation ? "https://www.bilibili.com/video/BV... 或合集链接" : "https://www.bilibili.com/video/BV..."}
-                  disabled={status === "loading"}
-                  className="w-full rounded-2xl border border-stone-200 bg-white px-4 py-2.5 text-sm font-medium text-stone-900 transition-all placeholder:text-stone-400 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10 disabled:opacity-60 dark:border-stone-700 dark:bg-neutral-900 dark:text-stone-100 dark:placeholder:text-zinc-500"
-                  autoFocus
-                />
-                <p className="mt-2 text-[11px] text-stone-400 dark:text-zinc-500">
-                  遇到风控时请先获取 Cookie，再重新解析。
-                </p>
-                <div className="mt-3 flex flex-wrap items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={handleInitBilibiliCookie}
-                    disabled={bilibiliCookieLoading || status === "loading"}
-                    className="inline-flex cursor-pointer items-center gap-2 rounded-2xl border border-accent/30 bg-accent/10 px-4 py-2 text-xs font-bold text-accent transition-colors hover:bg-accent/15 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {bilibiliCookieLoading ? <Loader2 size={14} className="animate-spin" /> : null}
-                    {bilibiliCookieLoading ? "等待登录..." : "获取 Bilibili Cookie"}
-                  </button>
-                  {bilibiliCookieConfigured ? (
-                    <span className="inline-flex items-center gap-1 text-xs font-semibold text-emerald-600 dark:text-emerald-400">
-                      <CheckCircle2 size={14} />
-                      Cookie 已写入
-                    </span>
-                  ) : null}
-                </div>
-                </>
+                  <>
+                    <label className="mb-2 block text-xs font-bold tracking-wide text-stone-600 dark:text-zinc-400">
+                      {isSeriesCreation ? "Bilibili 系列 / 多 P URL" : "Bilibili 视频 URL"}
+                    </label>
+                    <input
+                      type="url"
+                      value={url}
+                      onChange={(event) => setUrl(event.target.value)}
+                      placeholder={isSeriesCreation ? "https://www.bilibili.com/video/BV... 或合集链接" : "https://www.bilibili.com/video/BV..."}
+                      disabled={status === "loading" || status === "selecting"}
+                      className="w-full rounded-2xl border border-stone-200 bg-white px-4 py-2.5 text-sm font-medium text-stone-900 transition-all placeholder:text-stone-400 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10 disabled:opacity-60 dark:border-stone-700 dark:bg-neutral-900 dark:text-stone-100 dark:placeholder:text-zinc-500"
+                      autoFocus
+                    />
+                    <p className="mt-2 text-[11px] text-stone-500 dark:text-zinc-500">
+                      遇到风控时请先获取 Cookie，再重新解析。
+                    </p>
+                    <div className="mt-3 flex flex-wrap items-center gap-3">
+                      <button
+                        type="button"
+                        onClick={handleInitBilibiliCookie}
+                        disabled={bilibiliCookieLoading || status === "loading"}
+                        className="inline-flex cursor-pointer items-center gap-2 rounded-2xl border border-accent/30 bg-accent/10 px-4 py-2 text-xs font-bold text-accent transition-colors hover:bg-accent/15 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {bilibiliCookieLoading ? <Loader2 size={14} className="animate-spin" /> : null}
+                        {bilibiliCookieLoading ? "等待登录..." : "获取 Bilibili Cookie"}
+                      </button>
+                      {bilibiliCookieConfigured ? (
+                        <span className="inline-flex items-center gap-1 text-xs font-semibold text-emerald-600 dark:text-emerald-400">
+                          <CheckCircle2 size={14} />
+                          Cookie 已写入
+                        </span>
+                      ) : null}
+                    </div>
+                  </>
                 ) : (
                   <div className="rounded-2xl border border-stone-200 bg-stone-50 p-4 dark:border-stone-700 dark:bg-neutral-900">
                     {!chaoxingEnabledForMode ? (
@@ -441,7 +464,7 @@ export function WorkspaceImportModal({
                       <div className="flex flex-col gap-3">
                         <div>
                           <p className="text-sm font-bold text-stone-900 dark:text-stone-100">需要初始化超星登录</p>
-                          <p className="mt-1 text-xs text-stone-500 dark:text-zinc-400">
+                          <p className="mt-1 text-xs text-stone-600 dark:text-zinc-400">
                             点击后会打开浏览器，请在浏览器中完成学习通登录。
                           </p>
                         </div>
@@ -470,7 +493,7 @@ export function WorkspaceImportModal({
                           </button>
                         </div>
                         <div className="relative mb-3">
-                          <Search size={14} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-stone-400 dark:text-zinc-500" />
+                          <Search size={14} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-stone-500 dark:text-zinc-500" />
                           <input
                             type="text"
                             value={chaoxingCourseSearch}
@@ -482,7 +505,7 @@ export function WorkspaceImportModal({
                             <button
                               type="button"
                               onClick={() => setChaoxingCourseSearch("")}
-                              className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
+                              className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
                               aria-label="清空课程搜索"
                               title="清空课程搜索"
                             >
@@ -496,14 +519,13 @@ export function WorkspaceImportModal({
                               key={course.courseKey}
                               type="button"
                               onClick={() => setSelectedChaoxingCourseKey(course.courseKey)}
-                              className={`w-full cursor-pointer rounded-2xl border px-4 py-3 text-left transition-colors ${
-                                selectedChaoxingCourseKey === course.courseKey
+                              className={`w-full cursor-pointer rounded-2xl border px-4 py-3 text-left transition-colors ${selectedChaoxingCourseKey === course.courseKey
                                   ? "border-accent bg-accent/10"
                                   : "border-stone-200 bg-white dark:border-stone-700 dark:bg-neutral-950"
-                              }`}
+                                }`}
                             >
                               <p className="text-sm font-bold text-stone-900 dark:text-stone-100">{course.title}</p>
-                              <p className="mt-1 text-xs text-stone-500 dark:text-zinc-400">
+                              <p className="mt-1 text-xs text-stone-600 dark:text-zinc-400">
                                 {[course.teacher, course.openTime].filter(Boolean).join(" · ") || "超星课程"}
                               </p>
                             </button>
@@ -532,32 +554,65 @@ export function WorkspaceImportModal({
                   className="w-full rounded-2xl border border-stone-200 bg-white px-4 py-2.5 text-sm font-medium text-stone-900 transition-all placeholder:text-stone-400 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10 disabled:opacity-60 dark:border-stone-700 dark:bg-neutral-900 dark:text-stone-100 dark:placeholder:text-zinc-500"
                   autoFocus
                 />
+                <div className="mt-4">
+                  <p className="mb-2 text-xs font-bold tracking-wide text-stone-600 dark:text-zinc-400">媒体存储方式</p>
+                  <div className="grid grid-cols-2 gap-2" role="radiogroup" aria-label="媒体存储方式">
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={storageMode === "copy"}
+                      onClick={() => setStorageMode("copy")}
+                      disabled={status === "loading" || status === "selecting"}
+                      className={`flex items-center gap-2 rounded-lg border px-3 py-2.5 text-left text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${storageMode === "copy"
+                          ? "border-accent bg-accent/10 text-accent"
+                          : "border-stone-200 bg-white text-stone-700 hover:border-stone-300 dark:border-stone-700 dark:bg-neutral-900 dark:text-zinc-200"
+                        }`}
+                    >
+                      <Copy size={16} />
+                      复制到工作区
+                    </button>
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={storageMode === "hardlink"}
+                      onClick={() => setStorageMode("hardlink")}
+                      disabled={status === "loading" || status === "selecting" || (sourcePaths.length > 0 && !hardlinkAvailable)}
+                      className={`flex items-center gap-2 rounded-lg border px-3 py-2.5 text-left text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${storageMode === "hardlink"
+                          ? "border-accent bg-accent/10 text-accent"
+                          : "border-stone-200 bg-white text-stone-700 hover:border-stone-300 dark:border-stone-700 dark:bg-neutral-900 dark:text-zinc-200"
+                        }`}
+                    >
+                      <Link2 size={16} />
+                      创建硬链接(节约空间)
+                    </button>
+                  </div>
+                  {sourcePaths.length > 0 && !hardlinkAvailable ? (
+                    <p className="mt-2 text-xs font-medium text-danger">所选文件与工作区不在同一磁盘分区，只能复制导入。</p>
+                  ) : null}
+                </div>
               </div>
             ) : null}
 
             {sourceType === "local" ? (
-            <div>
-              <label className="mb-2 block text-xs font-bold tracking-wide text-stone-600 dark:text-zinc-400">
-                选择媒体文件
-              </label>
-              <label className="flex cursor-pointer flex-col gap-2 rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-4 py-4 transition hover:border-accent hover:bg-accent/5 dark:border-stone-700 dark:bg-neutral-900">
-                <div className="flex items-center gap-2 text-sm font-semibold text-stone-700 dark:text-stone-200">
-                  <Film size={16} />
-                  {selectedFileSummary}
-                </div>
-                <p className="text-xs text-stone-500 dark:text-zinc-400">
-                  支持多选，导入时会复制到项目媒体目录。
-                </p>
-                <input
-                  type="file"
-                  accept="video/*,audio/*,.mp4,.mov,.mkv,.avi,.webm,.m4v,.mp3,.wav,.m4a,.aac,.flac,.ogg,.opus,.wma"
-                  multiple
-                  disabled={status === "loading"}
-                  onChange={(event) => setFiles(Array.from(event.target.files ?? []))}
-                  className="hidden"
-                />
-              </label>
-            </div>
+              <div>
+                <label className="mb-2 block text-xs font-bold tracking-wide text-stone-600 dark:text-zinc-400">
+                  选择媒体文件
+                </label>
+                <button
+                  type="button"
+                  onClick={handleSelectLocalMedia}
+                  disabled={status === "loading" || status === "selecting"}
+                  className="flex w-full flex-col gap-2 rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-4 py-4 text-left transition hover:border-accent hover:bg-accent/5 disabled:cursor-not-allowed disabled:opacity-60 dark:border-stone-700 dark:bg-neutral-900"
+                >
+                  <div className="flex items-center gap-2 text-sm font-semibold text-stone-700 dark:text-stone-200">
+                    <Film size={16} />
+                    {selectedFileSummary}
+                  </div>
+                  <p className="text-xs text-stone-600 dark:text-zinc-400">
+                    {isSeriesCreation && storageMode === "hardlink" ? "支持多选，媒体文件需与工作区位于同一磁盘分区。" : "支持多选，媒体将按该系列的存储方式导入。"}
+                  </p>
+                </button>
+              </div>
             ) : null}
 
             {status === "success" && preview ? (

--- a/src/frontend/src/features/workspace/ui/WorkspaceLibraryHomePane.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceLibraryHomePane.jsx
@@ -52,7 +52,7 @@ export function WorkspaceLibraryHomePane({ library, onSelectSeries, onAddSeries,
 
           <h2 className="text-3xl lg:text-4xl font-extrabold tracking-tight text-stone-900 dark:text-stone-100">
             Welcome to your{" "}
-            <span className="text-stone-400 dark:text-zinc-500">Knowledge Base.</span>
+            <span className="text-stone-600 dark:text-zinc-500">Knowledge Base.</span>
           </h2>
 
         </motion.div>
@@ -63,12 +63,12 @@ export function WorkspaceLibraryHomePane({ library, onSelectSeries, onAddSeries,
           {/* Main Progress Card (Spans 8 cols) */}
           <motion.article variants={blurVariant} className="md:col-span-8 workspace-elevated-panel rounded-[2rem] border border-stone-200 dark:border-white/5 p-6 flex flex-col justify-between overflow-hidden relative">
             <div className="relative z-10">
-              <p className="text-[11px] font-bold uppercase tracking-widest text-stone-500 dark:text-zinc-500 mb-3 flex items-center gap-2">
+              <p className="text-[11px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-500 mb-3 flex items-center gap-2">
                 Processing Overview
               </p>
               <div className="flex items-baseline gap-3 mb-2">
                 <h3 className="text-5xl font-black text-stone-900 dark:text-stone-100 tracking-tighter">{progressPercentage}%</h3>
-                <p className="text-sm font-semibold text-stone-500 dark:text-zinc-400 pb-1">processed</p>
+                <p className="text-sm font-semibold text-stone-600 dark:text-zinc-400 pb-1">processed</p>
               </div>
 
               <div className="h-3 w-full bg-stone-200/60 dark:bg-neutral-900/80 rounded-full overflow-hidden mt-4 shadow-inner relative">
@@ -79,7 +79,7 @@ export function WorkspaceLibraryHomePane({ library, onSelectSeries, onAddSeries,
                   className="absolute top-0 left-0 h-full bg-accent rounded-full"
                 />
               </div>
-              <div className="flex justify-between items-center mt-3 text-xs font-semibold text-stone-500 dark:text-zinc-500">
+              <div className="flex justify-between items-center mt-3 text-xs font-semibold text-stone-600 dark:text-zinc-500">
                 <span>已解析 {librarySummary.processedVideos} 个视频</span>
                 <span>库内共计 {librarySummary.totalVideos} 个视频</span>
               </div>
@@ -90,19 +90,19 @@ export function WorkspaceLibraryHomePane({ library, onSelectSeries, onAddSeries,
           <motion.div variants={blurVariant} className="md:col-span-4 flex flex-col gap-4">
             <div className="workspace-panel flex-1 rounded-[2rem] border border-stone-200 dark:border-white/5 p-6 flex flex-col justify-center items-center text-center group">
               <span className="text-4xl font-black text-stone-900 dark:text-stone-100 mb-2 transition-transform group-hover:scale-105">{librarySummary.seriesCount}</span>
-              <span className="text-[10px] font-bold uppercase tracking-widest text-stone-500 dark:text-zinc-500">Total Series</span>
+              <span className="text-[10px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-500">Total Series</span>
             </div>
             <div className="workspace-panel flex-1 rounded-[2rem] border border-stone-200 dark:border-white/5 p-6 flex flex-col justify-center items-center text-center group">
               <span className="text-4xl font-black text-stone-900 dark:text-stone-100 mb-2 transition-transform group-hover:scale-105">{librarySummary.totalVideos}</span>
-              <span className="text-[10px] font-bold uppercase tracking-widest text-stone-500 dark:text-zinc-500">Total Videos</span>
+              <span className="text-[10px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-500">Total Videos</span>
             </div>
           </motion.div>
 
           {/* Recent Shelves (Spans 7 cols) */}
           <motion.article variants={blurVariant} className="md:col-span-7 workspace-panel rounded-[2rem] border border-stone-200 dark:border-white/5 p-6">
             <div className="flex items-center justify-between mb-4">
-              <p className="text-[11px] font-bold uppercase tracking-widest text-stone-500 dark:text-zinc-500">Recent Shelves</p>
-              <span className="text-[10px] font-bold uppercase text-stone-500 dark:text-zinc-400 bg-stone-100 dark:bg-neutral-900 px-2.5 py-1 rounded-full border border-stone-200 dark:border-white/5 shadow-sm">Top {librarySummary.latestSeries.length}</span>
+              <p className="text-[11px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-500">Recent Shelves</p>
+              <span className="text-[10px] font-bold uppercase text-stone-600 dark:text-zinc-400 bg-stone-100 dark:bg-neutral-900 px-2.5 py-1 rounded-full border border-stone-200 dark:border-white/5 shadow-sm">Top {librarySummary.latestSeries.length}</span>
             </div>
 
             {librarySummary.latestSeries.length > 0 ? (
@@ -118,7 +118,7 @@ export function WorkspaceLibraryHomePane({ library, onSelectSeries, onAddSeries,
                   >
                     <div>
                       <strong className="block text-[14px] font-bold text-stone-900 dark:text-stone-100 group-hover:text-accent transition-colors">{seriesItem.title}</strong>
-                      <span className="block text-xs font-semibold text-stone-500 dark:text-zinc-500 mt-1">{seriesItem.videos.length} 个视频片段</span>
+                      <span className="block text-xs font-semibold text-stone-600 dark:text-zinc-500 mt-1">{seriesItem.videos.length} 个视频片段</span>
                     </div>
                     <div className="w-8 h-8 rounded-full bg-stone-200/50 dark:bg-neutral-800 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all -translate-x-2 group-hover:translate-x-0 border border-stone-300/50 dark:border-white/5">
                       <span className="text-stone-600 dark:text-zinc-300 text-xs font-bold">→</span>
@@ -128,7 +128,7 @@ export function WorkspaceLibraryHomePane({ library, onSelectSeries, onAddSeries,
               </div>
             ) : (
               <div className="h-32 flex items-center justify-center border-2 border-dashed border-stone-200 dark:border-white/5 rounded-2xl">
-                <p className="text-sm font-semibold text-stone-400">暂无阅读记录</p>
+                <p className="text-sm font-semibold text-stone-500">暂无阅读记录</p>
               </div>
             )}
           </motion.article>
@@ -136,18 +136,18 @@ export function WorkspaceLibraryHomePane({ library, onSelectSeries, onAddSeries,
           {/* Playground Card (Spans 5 cols) */}
           <motion.article variants={blurVariant} className="md:col-span-5 workspace-muted-panel rounded-[2rem] border border-stone-200 dark:border-white/5 p-6 relative overflow-hidden flex flex-col">
             <div className="absolute top-0 right-0 w-40 h-40 bg-accent/10 dark:bg-accent/[0.06] rounded-full blur-3xl -mr-10 -mt-10 pointer-events-none" />
-            <p className="text-[11px] font-bold uppercase tracking-widest text-stone-500 dark:text-zinc-500 mb-4 relative z-10">Playground</p>
+            <p className="text-[11px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-500 mb-4 relative z-10">Playground</p>
             <div className="relative z-10 flex flex-col gap-4 flex-1">
               <div>
                 <h3 className="text-2xl font-extrabold tracking-tight text-stone-900 dark:text-stone-100">排练场</h3>
-                <p className="mt-2 text-sm font-medium leading-relaxed text-stone-500 dark:text-zinc-400">
+                <p className="mt-2 text-sm font-medium leading-relaxed text-stone-600 dark:text-zinc-400">
                   处理非系列视频
                 </p>
               </div>
               <div className="mt-2">
                 <div className="flex items-baseline gap-3 mb-2">
                   <h3 className="text-3xl font-black text-stone-900 dark:text-stone-100 tracking-tighter">{playgroundProgressPercentage}%</h3>
-                  <p className="text-xs font-semibold text-stone-500 dark:text-zinc-400 pb-1">AI 处理率</p>
+                  <p className="text-xs font-semibold text-stone-600 dark:text-zinc-400 pb-1">AI 处理率</p>
                 </div>
                 <div className="h-2.5 w-full bg-stone-200/60 dark:bg-neutral-900/80 rounded-full overflow-hidden mt-3 shadow-inner relative">
                   <motion.div
@@ -157,7 +157,7 @@ export function WorkspaceLibraryHomePane({ library, onSelectSeries, onAddSeries,
                     className="absolute top-0 left-0 h-full bg-accent rounded-full"
                   />
                 </div>
-                <div className="flex justify-between items-center mt-3 text-xs font-semibold text-stone-500 dark:text-zinc-500">
+                <div className="flex justify-between items-center mt-3 text-xs font-semibold text-stone-600 dark:text-zinc-500">
                   <span>已解析 {playgroundProcessedCount} 个视频</span>
                   <span>库内共计 {playgroundVideoCount} 个视频</span>
                 </div>

--- a/src/frontend/src/features/workspace/ui/WorkspaceLibraryPanel.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceLibraryPanel.jsx
@@ -45,7 +45,7 @@ function VideoBadge({ video }) {
     );
   }
   return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-stone-100 dark:bg-stone-800 text-stone-500 dark:text-stone-400 border border-transparent">
+    <span className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 border border-transparent">
       <CircleDashed size={12} />
       未处理
     </span>
@@ -108,7 +108,7 @@ function SourceVideoLink({ sourceUrl, provider }) {
       href={sourceUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-stone-200 bg-stone-100 text-stone-500 transition-colors hover:border-accent/30 hover:text-accent dark:border-white/10 dark:bg-neutral-800 dark:text-zinc-400"
+      className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-stone-200 bg-stone-100 text-stone-600 transition-colors hover:border-accent/30 hover:text-accent dark:border-white/10 dark:bg-neutral-800 dark:text-zinc-400"
       title="在 Bilibili 中查看"
     >
       <ExternalLink size={15} />
@@ -149,7 +149,7 @@ function PanelFooter({
 
           <h3 className="text-sm font-bold text-stone-800 dark:text-stone-100">Playground Workspace</h3>
         </div>
-        <p className="text-xs leading-relaxed text-stone-500 dark:text-stone-400">
+        <p className="text-xs leading-relaxed text-stone-600 dark:text-stone-400">
           添加或选择一个视频
         </p>
       </div>
@@ -166,10 +166,10 @@ function PanelFooter({
     return (
       <div className="workspace-toolbar-surface p-4 pr-6 border-t border-stone-200/80 dark:border-stone-800 flex-shrink-0">
         <div className="mb-1">
-          <p className="text-[10px] font-bold text-stone-500 dark:text-stone-400 tracking-wider uppercase mb-1 drop-shadow-sm">Now Look At:</p>
+          <p className="text-[10px] font-bold text-stone-600 dark:text-stone-400 tracking-wider uppercase mb-1 drop-shadow-sm">Now Look At:</p>
           <h3 className="text-sm font-bold text-stone-800 dark:text-stone-100">Series scope</h3>
         </div>
-        <p className="text-xs leading-relaxed text-stone-500 dark:text-stone-400">
+        <p className="text-xs leading-relaxed text-stone-600 dark:text-stone-400">
           {embeddingNeedsDownload
             ? "当前向量检索模型尚未下载，下载后才能使用 series 问答。"
             : `你可以在当前对话栏询问关于整个系列的问题 ： ${activeSeries?.title}。`}
@@ -221,7 +221,7 @@ function PanelFooter({
   if (!selectedVideo) {
     return (
       <div className="workspace-toolbar-surface p-4 pr-6 border-t border-stone-200/80 dark:border-stone-800 flex justify-center items-center h-[98px]">
-        <p className="text-xs text-stone-400 dark:text-stone-500 font-medium">可选择整个系列，或点某个视频进入视频工具</p>
+        <p className="text-xs text-stone-500 dark:text-stone-500 font-medium">可选择整个系列，或点某个视频进入视频工具</p>
       </div>
     );
   }
@@ -232,7 +232,7 @@ function PanelFooter({
     return (
       <div className="workspace-toolbar-surface p-4 pr-6 border-t border-stone-200/80 dark:border-stone-800 flex-shrink-0">
         <div className="mb-3">
-          <p className="text-[10px] font-bold text-stone-500 dark:text-stone-400 tracking-wider uppercase mb-1 drop-shadow-sm">下载中</p>
+          <p className="text-[10px] font-bold text-stone-600 dark:text-stone-400 tracking-wider uppercase mb-1 drop-shadow-sm">下载中</p>
           <h3 className="text-sm font-bold text-stone-800 dark:text-stone-100 truncate">{selectedVideo.title}</h3>
         </div>
         <div className="relative w-full overflow-hidden rounded-full bg-stone-200 h-2.5 mb-1.5 dark:bg-neutral-800">
@@ -250,7 +250,7 @@ function PanelFooter({
             />
           )}
         </div>
-        <p className="text-xs text-stone-500 dark:text-zinc-400 font-medium">
+        <p className="text-xs text-stone-600 dark:text-zinc-400 font-medium">
           {hasDownloadProgress ? `${pct.toFixed(0)}% 完成` : "下载中"}
         </p>
         <button
@@ -269,7 +269,7 @@ function PanelFooter({
     return (
       <div className="workspace-toolbar-surface p-4 pr-6 border-t border-stone-200/80 dark:border-stone-800 flex-shrink-0">
         <div className="mb-3">
-          <p className="text-[10px] font-bold text-stone-500 dark:text-stone-400 tracking-wider uppercase mb-1 drop-shadow-sm">当前视频</p>
+          <p className="text-[10px] font-bold text-stone-600 dark:text-stone-400 tracking-wider uppercase mb-1 drop-shadow-sm">当前视频</p>
           <h3 className="text-sm font-bold text-stone-800 dark:text-stone-100 truncate" title={selectedVideo.title}>{selectedVideo.title}</h3>
         </div>
         <div className="flex gap-2">
@@ -313,7 +313,7 @@ function PanelFooter({
   return (
     <div className="workspace-toolbar-surface p-4 pr-6 border-t border-stone-200/80 dark:border-stone-800 flex-shrink-0">
       <div className="mb-3">
-        <p className="text-[10px] font-bold text-stone-500 dark:text-stone-400 tracking-wider uppercase mb-1 drop-shadow-sm">当前视频</p>
+        <p className="text-[10px] font-bold text-stone-600 dark:text-stone-400 tracking-wider uppercase mb-1 drop-shadow-sm">当前视频</p>
         <h3 className="text-sm font-bold text-stone-800 dark:text-stone-100 truncate" title={selectedVideo.title}>{selectedVideo.title}</h3>
       </div>
       {modelNeedsDownload ? (
@@ -327,7 +327,7 @@ function PanelFooter({
           className={`flex-1 inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-2xl font-semibold text-sm transition-all duration-200 ${videoGenerationButton.tone === "danger"
             ? "btn-danger-ghost border border-red-200 text-red-600 dark:border-red-900/70 dark:text-red-300"
             : videoGenerationButton.tone === "busy"
-              ? "motion-busy-button bg-stone-200 dark:bg-stone-800 text-stone-500 dark:text-stone-400 cursor-not-allowed"
+              ? "motion-busy-button bg-stone-200 dark:bg-stone-800 text-stone-600 dark:text-stone-400 cursor-not-allowed"
               : "border border-accent/40 bg-accent/8 text-accent hover:bg-accent/14 hover:border-accent/60 shadow-none active:scale-[0.98]"
             }`}
           onClick={
@@ -430,7 +430,7 @@ export function WorkspaceLibraryPanel({
           </div>
           <button
             type="button"
-            className="inline-flex items-center justify-center w-8 h-8 rounded-full text-stone-500 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+            className="inline-flex items-center justify-center w-8 h-8 rounded-full text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
             onClick={onEnterLibraryHome}
             title="返回分类列表"
           >
@@ -472,7 +472,7 @@ export function WorkspaceLibraryPanel({
 
         {!isPlayground ? (
           <div className="relative">
-            <Search size={14} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-stone-400 dark:text-stone-500" />
+            <Search size={14} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-stone-500 dark:text-stone-500" />
             <input
               type="text"
               value={filterText}
@@ -484,7 +484,7 @@ export function WorkspaceLibraryPanel({
               <button
                 type="button"
                 onClick={() => setFilterText("")}
-                className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
+                className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
                 aria-label="清空筛选条件"
                 title="清空筛选条件"
               >
@@ -518,7 +518,7 @@ export function WorkspaceLibraryPanel({
               <strong className="text-base font-semibold line-clamp-2 tracking-[-0.01em] text-stone-900 dark:text-stone-100">
                 {activeSeries?.title}
               </strong>
-              <span className="text-xs truncate text-stone-500 dark:text-stone-400">
+              <span className="text-xs truncate text-stone-600 dark:text-stone-400">
                 聚焦整个 series，供 AI 和工具使用系列级上下文
               </span>
             </div>
@@ -548,7 +548,7 @@ export function WorkspaceLibraryPanel({
               )}
               <div className="flex justify-between items-start w-full gap-2">
                 <VideoBadge video={video} />
-                <FileVideo size={16} className={isActive ? "text-accent" : "text-stone-400 dark:text-stone-500"} />
+                <FileVideo size={16} className={isActive ? "text-accent" : "text-stone-500 dark:text-stone-500"} />
               </div>
               <div className="flex flex-col gap-0.5 mt-1">
                 <strong className={`text-sm font-semibold line-clamp-2 ${isActive ? "text-stone-900 dark:text-stone-100" : "text-stone-800 dark:text-stone-100"}`}>
@@ -562,7 +562,7 @@ export function WorkspaceLibraryPanel({
                     {video.coreProblem}
                   </span>
                 ) : null}
-                <span className="text-xs text-stone-500 dark:text-stone-400 truncate">
+                <span className="text-xs text-stone-600 dark:text-stone-400 truncate">
                   {video.isLinked || video.status === "linked" ? video.sourceUrl || video.sourceName : video.sourceName}
                 </span>
               </div>
@@ -570,7 +570,7 @@ export function WorkspaceLibraryPanel({
           );
         })}
         {!isPlayground && filteredVideos.length === 0 ? (
-          <div className="workspace-elevated-panel rounded-[1.5rem] border border-dashed border-stone-200/80 px-4 py-8 text-center text-sm text-stone-500 dark:border-stone-800 dark:text-stone-400">
+          <div className="workspace-elevated-panel rounded-[1.5rem] border border-dashed border-stone-200/80 px-4 py-8 text-center text-sm text-stone-600 dark:border-stone-800 dark:text-stone-400">
             当前筛选条件下没有匹配的视频。
           </div>
         ) : null}

--- a/src/frontend/src/features/workspace/ui/WorkspacePage.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspacePage.jsx
@@ -11,6 +11,7 @@ import { WorkspaceImportModal } from "./WorkspaceImportModal";
 import { WorkspaceConfirmDialog } from "./shared/WorkspaceConfirmDialog";
 import { motion, AnimatePresence } from "framer-motion";
 import { blurVariant } from "../../../lib/animations";
+import { useFocusTrap } from "../../../shared/lib/useFocusTrap";
 import { WorkspaceStateBlock } from "./shared/WorkspaceStateBlock";
 import {
   clampMiddleWidth,
@@ -68,6 +69,12 @@ export function WorkspacePage({ page }) {
   const [pendingDelete, setPendingDelete] = useState(null);
   const [deletePending, setDeletePending] = useState(false);
   const containerRef = useRef(null);
+  const settingsModalRef = useRef(null);
+  const usageModalRef = useRef(null);
+  // Engage focus trap on open modals so keyboard users stay inside
+  // (WCAG 2.4.3 Focus Order) and focus returns to the trigger on close.
+  useFocusTrap(settingsModalRef, state.settingsPanelOpen);
+  useFocusTrap(usageModalRef, state.usagePageOpen);
   const isPlaygroundHome = activeSeries?.id === "__playground__" && !selectedVideo;
   const currentAsrModel = generation.fasterWhisperModels?.find((model) => model.id === ui.asrModelQuality) ?? null;
   const hasRightPane = Boolean(activeSeries);
@@ -227,7 +234,7 @@ export function WorkspacePage({ page }) {
           <h1 className="text-2xl font-bold text-stone-900 mb-3">
             {waitingForBackend ? "正在启动服务..." : "正在载入知识工作台"}
           </h1>
-          <p className="text-stone-500">
+          <p className="text-stone-600">
             {waitingForBackend
               ? "正在等待后端服务响应，连接成功后会自动进入工作区。"
               : "正在扫描 `videos/` 目录并构建当前工作区。"}
@@ -340,7 +347,7 @@ export function WorkspacePage({ page }) {
         />
 
         {state.error && (
-          <div className="mx-6 mt-4 flex items-start justify-between gap-4 rounded-2xl border border-red-100 bg-red-50/90 p-4 text-sm text-red-800 dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-200 flex-shrink-0 relative z-20">
+          <div className="mx-6 mt-4 flex items-start justify-between gap-4 rounded-2xl border border-danger bg-danger-subtle p-4 text-sm text-danger flex-shrink-0 relative z-20">
             <div className="min-w-0 flex-1 break-words">
               {state.error}
             </div>
@@ -348,7 +355,7 @@ export function WorkspacePage({ page }) {
               <button
                 type="button"
                 onClick={actions.clearError}
-                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-red-500 transition-colors hover:bg-red-100 hover:text-red-700 dark:text-red-300 dark:hover:bg-red-950/50 dark:hover:text-red-100"
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-danger-muted transition-colors hover:bg-danger-subtle hover:text-danger"
                 title="关闭错误提示"
                 aria-label="关闭错误提示"
               >
@@ -434,10 +441,17 @@ export function WorkspacePage({ page }) {
         <AnimatePresence>
           {state.settingsPanelOpen && (
             <motion.div
+              ref={settingsModalRef}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2 }}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  actions.closeSettingsPanel();
+                }
+              }}
               className="absolute inset-0 z-50 bg-stone-900/20 dark:bg-black/50 backdrop-blur-md flex justify-center items-center p-4 md:p-8"
             >
               <Suspense fallback={<WorkspaceModalLoadingState />}>
@@ -479,10 +493,17 @@ export function WorkspacePage({ page }) {
         <AnimatePresence>
           {state.usagePageOpen && (
             <motion.div
+              ref={usageModalRef}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2 }}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  actions.closeUsagePage();
+                }
+              }}
               className="absolute inset-0 z-50 bg-stone-900/20 dark:bg-black/50 backdrop-blur-md flex justify-center items-center p-4 md:p-8"
             >
               <Suspense fallback={<WorkspaceModalLoadingState />}>
@@ -527,9 +548,10 @@ export function WorkspacePage({ page }) {
           onCancelChaoxingImport={actions.cancelChaoxingImport}
           onLoadChaoxingCourses={actions.loadChaoxingCourses}
           onImportChaoxingCourse={actions.importChaoxingCourse}
-          onImportLocalSeries={async (seriesTitle, files) => actions.importLocalSeries(seriesTitle, files)}
-          onImportSeriesVideos={async (seriesId, files) => actions.importSeriesVideos(seriesId, files)}
-          onImportLocalPlaygroundVideos={async (files) => actions.importLocalPlaygroundVideos(files)}
+          onSelectLocalMedia={actions.selectLocalMedia}
+          onImportLocalSeries={async (seriesTitle, sourcePaths, storageMode) => actions.importLocalSeries(seriesTitle, sourcePaths, storageMode)}
+          onImportSeriesVideos={async (seriesId, sourcePaths) => actions.importSeriesVideos(seriesId, sourcePaths)}
+          onImportLocalPlaygroundVideos={async (sourcePaths) => actions.importLocalPlaygroundVideos(sourcePaths)}
         />
       )}
 
@@ -595,8 +617,8 @@ function WorkspaceKnowledgeMemoryStatusBar({ snapshot }) {
     : snapshot.detail ?? (isRunning ? "正在重建 RAG 索引与 catalog 记忆。" : "RAG 索引已可用于检索。");
   const progressText = typeof snapshot.progress === "number" ? `${Math.round(snapshot.progress)}%` : "";
   const toneClassName = isFailed
-    ? "border-red-100 bg-red-50/90 text-red-800 dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-200"
-    : "border-amber-100 bg-amber-50/90 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100";
+    ? "border-danger bg-danger-subtle text-danger"
+    : "border-warning bg-warning-subtle text-warning";
 
   return (
     <div className={`mx-6 mt-4 flex items-center gap-3 rounded-2xl border px-4 py-3 text-sm ${toneClassName}`}>

--- a/src/frontend/src/features/workspace/ui/WorkspaceReadingPane.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceReadingPane.jsx
@@ -373,9 +373,9 @@ function WorkspaceHomeHeader({ eyebrow, title, description, children }) {
   return (
     <div className="flex items-start justify-between gap-4">
       <div>
-        <p className="mb-1 text-xs font-bold uppercase text-stone-500 dark:text-stone-400">{eyebrow}</p>
+        <p className="mb-1 text-xs font-bold uppercase text-stone-600 dark:text-stone-400">{eyebrow}</p>
         <h2 className="text-2xl font-bold leading-snug text-stone-900 dark:text-stone-100">{title}</h2>
-        <p className="mt-2 text-sm text-stone-500 dark:text-stone-400">{description}</p>
+        <p className="mt-2 text-sm text-stone-600 dark:text-stone-400">{description}</p>
       </div>
       {children ? <div className="shrink-0">{children}</div> : null}
     </div>

--- a/src/frontend/src/features/workspace/ui/WorkspaceSeriesGrid.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceSeriesGrid.jsx
@@ -28,12 +28,12 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
   if (!sourceSeries.length) {
     return (
       <section className="flex flex-col items-center justify-center min-h-[60vh] max-w-2xl mx-auto text-center p-12 workspace-panel rounded-[2rem] border m-6">
-        <div className="w-16 h-16 workspace-muted-panel rounded-2xl border flex items-center justify-center text-stone-400 mb-6 shadow-sm">
+        <div className="w-16 h-16 workspace-muted-panel rounded-2xl border flex items-center justify-center text-stone-500 mb-6 shadow-sm">
           <FolderKanban size={32} />
         </div>
-        <p className="text-[11px] font-bold text-stone-500 dark:text-zinc-500 tracking-widest uppercase mb-4">Videos Library</p>
+        <p className="text-[11px] font-bold text-stone-600 dark:text-zinc-500 tracking-widest uppercase mb-4">Videos Library</p>
         <h2 className="text-3xl font-bold text-stone-900 dark:text-stone-100 mb-4 tracking-tight">还没有分类 (Series)</h2>
-        <p className="text-stone-500 dark:text-zinc-400 leading-relaxed text-lg font-medium">
+        <p className="text-stone-600 dark:text-zinc-400 leading-relaxed text-lg font-medium">
           你可以直接使用导入入口创建系列，也可以手动把视频放进
           <code className="bg-stone-100 dark:bg-neutral-900 px-2 py-1 rounded-md text-stone-700 dark:text-zinc-300 font-mono text-sm mx-1 border border-stone-200 dark:border-white/5">videos/&lt;series&gt;/</code>
           目录。
@@ -61,11 +61,11 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
     return (
       <section className="flex h-full flex-col bg-transparent">
         <div className="border-b border-stone-200/80 dark:border-white/5 px-6 pb-5 pt-6 bg-stone-50/50 dark:bg-transparent">
-          <p className="text-[11px] font-bold uppercase tracking-widest text-stone-500 dark:text-zinc-500 mb-1.5 flex items-center gap-2">
+          <p className="text-[11px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-500 mb-1.5 flex items-center gap-2">
             Series Shelf
           </p>
           <h2 className="text-2xl font-extrabold text-stone-900 dark:text-stone-100 tracking-tight">All Shelves</h2>
-          <p className="mt-2 text-[13px] font-medium leading-relaxed text-stone-500 dark:text-zinc-400">
+          <p className="mt-2 text-[13px] font-medium leading-relaxed text-stone-600 dark:text-zinc-400">
             点击下方任一系列来进入工作区
           </p>
 
@@ -79,7 +79,7 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
             </button>
           ) : null}
           <div className="relative mt-4">
-            <Search size={14} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-stone-400 dark:text-stone-500" />
+            <Search size={14} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-stone-500 dark:text-stone-500" />
             <input
               type="text"
               value={searchText}
@@ -91,7 +91,7 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
               <button
                 type="button"
                 onClick={() => setSearchText("")}
-                className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
+                className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
                 aria-label="清空系列搜索"
                 title="清空系列搜索"
               >
@@ -122,20 +122,20 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
                     <span className="inline-flex items-center rounded-full bg-stone-100 dark:bg-neutral-900 border border-stone-200/50 dark:border-white/5 px-3 py-1 text-[11px] font-bold tracking-wide text-stone-600 dark:text-zinc-400 shadow-sm">
                       {seriesItem.videos.length} videos
                     </span>
-                    <span className="motion-arrow-shift flex h-8 w-8 items-center justify-center rounded-full bg-stone-50 dark:bg-neutral-900 border border-stone-200/50 dark:border-white/5 text-stone-400 dark:text-zinc-500 transition-colors group-hover:bg-accent group-hover:border-accent group-hover:text-white shadow-sm">
+                    <span className="motion-arrow-shift flex h-8 w-8 items-center justify-center rounded-full bg-stone-50 dark:bg-neutral-900 border border-stone-200/50 dark:border-white/5 text-stone-600 dark:text-zinc-500 transition-colors group-hover:bg-accent group-hover:border-accent group-hover:text-white shadow-sm">
                       <ArrowRight size={15} strokeWidth={2.5} />
                     </span>
                   </div>
                   <strong className="text-lg font-extrabold tracking-tight leading-tight text-stone-900 dark:text-stone-100 relative z-10 group-hover:text-accent transition-colors">{seriesItem.title}</strong>
-                  <p className="mt-1 truncate font-mono text-[11px] font-medium text-stone-400 dark:text-zinc-500 relative z-10">videos/{seriesItem.id}/</p>
+                  <p className="mt-1 truncate font-mono text-[11px] font-medium text-stone-600 dark:text-zinc-500 relative z-10">videos/{seriesItem.id}/</p>
 
                   <div className="mt-5 border-t border-stone-200/60 dark:border-white/5 pt-4 text-xs relative z-10">
                     <span className="inline-flex items-center gap-2 font-bold text-stone-600 dark:text-zinc-300">
                       <PlayCircle size={14} className="text-accent" />
                       {processedCount} / {seriesItem.videos.length} 已处理
                     </span>
-                    <span className="mt-2.5 inline-flex items-start gap-2 font-medium text-stone-500 dark:text-zinc-500 w-full">
-                      <Sparkles size={13} className="mt-0.5 shrink-0 text-stone-400 dark:text-zinc-600" />
+                    <span className="mt-2.5 inline-flex items-start gap-2 font-medium text-stone-600 dark:text-zinc-500 w-full">
+                      <Sparkles size={13} className="mt-0.5 shrink-0 text-stone-600 dark:text-zinc-600" />
                       <span className="truncate">最近：{latestVideo?.title ?? "无"}</span>
                     </span>
                   </div>
@@ -144,7 +144,7 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
             })}
           </motion.div>
           ) : (
-            <div className="workspace-elevated-panel rounded-[1.5rem] border border-dashed border-stone-200/80 px-4 py-8 text-center text-sm font-semibold text-stone-500 dark:border-stone-800 dark:text-stone-400">
+            <div className="workspace-elevated-panel rounded-[1.5rem] border border-dashed border-stone-200/80 px-4 py-8 text-center text-sm font-semibold text-stone-600 dark:border-stone-800 dark:text-stone-400">
               没有匹配的系列。
             </div>
           )}
@@ -162,12 +162,12 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-stone-100 dark:bg-neutral-900 border border-stone-200 dark:border-white/5 w-fit shadow-sm mb-5">
             <span className="text-[10px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-400">Videos Library</span>
           </div>
-          <h2 className="text-4xl lg:text-5xl font-extrabold text-stone-900 dark:text-stone-100 mb-4 tracking-tight">All Shelves <span className="text-stone-400 dark:text-zinc-600 font-medium">(Series)</span></h2>
+          <h2 className="text-4xl lg:text-5xl font-extrabold text-stone-900 dark:text-stone-100 mb-4 tracking-tight">All Shelves <span className="text-stone-600 dark:text-zinc-600 font-medium">(Series)</span></h2>
           <p className="text-stone-600 dark:text-zinc-400 text-[15px] font-medium leading-relaxed">
             首页总览所有的视频分类。点击进入某个分类后，可以查看具体视频、生成 AI 总结，并在右侧阅读核心要点。
           </p>
           <div className="relative mt-6 max-w-md">
-            <Search size={15} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-stone-400 dark:text-zinc-500" />
+            <Search size={15} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-stone-600 dark:text-zinc-500" />
             <input
               type="text"
               value={searchText}
@@ -179,7 +179,7 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
               <button
                 type="button"
                 onClick={() => setSearchText("")}
-                className="absolute right-3 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
+                className="absolute right-3 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-700 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-200"
                 aria-label="清空系列搜索"
                 title="清空系列搜索"
               >
@@ -201,11 +201,11 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
       {/* Overview Stats Row */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-12">
         <article className="flex flex-col p-8 rounded-[2rem] workspace-panel border shadow-sm relative overflow-hidden group">
-          <span className="text-[11px] font-bold text-stone-500 dark:text-zinc-500 uppercase tracking-widest mb-3 relative z-10">系列总数</span>
+          <span className="text-[11px] font-bold text-stone-600 dark:text-zinc-500 uppercase tracking-widest mb-3 relative z-10">系列总数</span>
           <strong className="text-5xl font-black tracking-tighter text-stone-900 dark:text-stone-100 relative z-10 transition-transform group-hover:scale-105 origin-left">{series.length}</strong>
         </article>
         <article className="flex flex-col p-8 rounded-[2rem] workspace-panel border shadow-sm relative overflow-hidden group">
-          <span className="text-[11px] font-bold text-stone-500 dark:text-zinc-500 uppercase tracking-widest mb-3 relative z-10">视频总数</span>
+          <span className="text-[11px] font-bold text-stone-600 dark:text-zinc-500 uppercase tracking-widest mb-3 relative z-10">视频总数</span>
           <strong className="text-5xl font-black tracking-tighter text-stone-900 dark:text-stone-100 relative z-10 transition-transform group-hover:scale-105 origin-left">{totalVideos}</strong>
         </article>
         <article className="workspace-panel border-accent/30 bg-accent/5 dark:bg-accent/10 flex flex-col p-8 rounded-[2rem] shadow-sm relative overflow-hidden group">
@@ -239,7 +239,7 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
                 <span className="inline-flex items-center px-3 py-1 rounded-full bg-stone-100 dark:bg-neutral-900 border border-stone-200/50 dark:border-white/5 text-stone-600 dark:text-zinc-400 text-[11px] font-bold tracking-wide shadow-sm">
                   {seriesItem.videos.length} videos
                 </span>
-                <span className="motion-arrow-shift w-9 h-9 rounded-full bg-stone-50 dark:bg-neutral-900 border border-stone-200/50 dark:border-white/5 flex items-center justify-center text-stone-400 dark:text-zinc-500 group-hover:bg-accent group-hover:border-accent group-hover:text-white transition-colors shadow-sm">
+                <span className="motion-arrow-shift w-9 h-9 rounded-full bg-stone-50 dark:bg-neutral-900 border border-stone-200/50 dark:border-white/5 flex items-center justify-center text-stone-600 dark:text-zinc-500 group-hover:bg-accent group-hover:border-accent group-hover:text-white transition-colors shadow-sm">
                   <ArrowRight size={16} strokeWidth={2.5} />
                 </span>
               </div>
@@ -249,7 +249,7 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
                 <strong className="text-2xl font-extrabold tracking-tight text-stone-900 dark:text-stone-100 leading-tight group-hover:text-accent transition-colors">
                   {seriesItem.title}
                 </strong>
-                <p className="text-[12px] font-medium font-mono text-stone-400 dark:text-zinc-500 truncate">
+                <p className="text-[12px] font-medium font-mono text-stone-600 dark:text-zinc-500 truncate">
                   videos/{seriesItem.id}/
                 </p>
               </div>
@@ -260,8 +260,8 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
                   <PlayCircle size={15} className="text-accent" />
                   {processedCount} / {seriesItem.videos.length} 已处理
                 </span>
-                <span className="inline-flex items-start gap-2.5 text-xs font-medium text-stone-500 dark:text-zinc-500">
-                  <Sparkles size={14} className="text-stone-400 dark:text-zinc-600 shrink-0 mt-0.5" />
+                <span className="inline-flex items-start gap-2.5 text-xs font-medium text-stone-600 dark:text-zinc-500">
+                  <Sparkles size={14} className="text-stone-600 dark:text-zinc-600 shrink-0 mt-0.5" />
                   <span className="truncate">最近：{latestVideo?.title ?? "无"}</span>
                 </span>
               </div>
@@ -270,7 +270,7 @@ export function WorkspaceSeriesGrid({ library, onOpenSeries, onAddSeries, compac
         })}
       </motion.div>
       ) : (
-        <div className="workspace-elevated-panel rounded-[2rem] border border-dashed border-stone-200/80 px-6 py-12 text-center text-sm font-semibold text-stone-500 dark:border-stone-800 dark:text-stone-400">
+        <div className="workspace-elevated-panel rounded-[2rem] border border-dashed border-stone-200/80 px-6 py-12 text-center text-sm font-semibold text-stone-600 dark:border-stone-800 dark:text-stone-400">
           没有匹配的系列。
         </div>
       )}

--- a/src/frontend/src/features/workspace/ui/WorkspaceSettingsPanel.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceSettingsPanel.jsx
@@ -129,7 +129,7 @@ export function WorkspaceSettingsPanel({
         <div className="mt-auto pt-6 border-t border-stone-200/80 dark:border-stone-800/50">
           <button
             type="button"
-            className="w-full text-left px-3 py-2 rounded-lg text-[13px] font-semibold text-stone-500 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
+            className="w-full text-left px-3 py-2 rounded-lg text-[13px] font-semibold text-stone-600 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
             onClick={() => setShowResetConfirm(true)}
           >
             恢复默认设置
@@ -142,7 +142,7 @@ export function WorkspaceSettingsPanel({
         <div className="sticky top-0 bg-white/80 dark:bg-neutral-950/80 backdrop-blur-md z-30 p-6 flex justify-end">
           <button
             type="button"
-            className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-stone-100 dark:bg-stone-800 text-stone-500 hover:bg-stone-200 dark:hover:bg-stone-700 transition-colors shadow-sm"
+            className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-stone-100 dark:bg-stone-800 text-stone-600 hover:bg-stone-200 dark:hover:bg-stone-700 transition-colors shadow-sm"
             onClick={onClose}
             aria-label="关闭面板"
           >
@@ -162,7 +162,7 @@ export function WorkspaceSettingsPanel({
               <>
                 <div className="mb-2">
                   <h3 className="text-2xl font-bold text-stone-900 dark:text-stone-100">常规与显示</h3>
-                  <p className="text-[13px] text-stone-500 dark:text-stone-400 mt-2">这里的配置会写入后端的 `settings.toml` 并实时生效</p>
+                  <p className="text-[13px] text-stone-600 dark:text-stone-400 mt-2">这里的配置会写入后端的 `settings.toml` 并实时生效</p>
                 </div>
 
                 {/* Theme Setting */}
@@ -210,7 +210,7 @@ export function WorkspaceSettingsPanel({
               <>
                 <div className="mb-2">
                   <h3 className="text-2xl font-bold text-stone-900 dark:text-stone-100">AI 总结能力</h3>
-                  <p className="text-[13px] text-stone-500 dark:text-stone-400 mt-2">控制总结流程，会写入 `settings.toml`。</p>
+                  <p className="text-[13px] text-stone-600 dark:text-stone-400 mt-2">控制总结流程，会写入 `settings.toml`。</p>
                 </div>
 
                 <WorkspaceSettingRow
@@ -249,7 +249,7 @@ export function WorkspaceSettingsPanel({
                 >
                   <div className="w-full flex flex-col gap-3">
                     {fasterWhisperModelsLoading && !fasterWhisperModels.length ? (
-                      <div className="flex items-center gap-2 text-sm text-stone-500 dark:text-stone-400">
+                      <div className="flex items-center gap-2 text-sm text-stone-600 dark:text-stone-400">
                         <LoaderCircle size={16} className="animate-spin" />
                         正在读取模型状态...
                       </div>
@@ -301,7 +301,7 @@ export function WorkspaceSettingsPanel({
                                     </span>
                                   ) : null}
                                 </div>
-                                <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+                                <p className="mt-1 text-xs text-stone-600 dark:text-stone-400">
                                   {isDownloading
                                     ? `正在下载... ${typeof downloadProgress === "number" ? `${Math.round(downloadProgress)}%` : ""}`.trim()
                                     : isCancelling
@@ -326,7 +326,7 @@ export function WorkspaceSettingsPanel({
                                 <button
                                   type="button"
                                   disabled
-                                  className="rounded-xl border border-stone-200 bg-white px-3 py-2 text-xs font-bold text-stone-400 disabled:cursor-wait disabled:opacity-70 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-500"
+                                  className="rounded-xl border border-stone-200 bg-white px-3 py-2 text-xs font-bold text-stone-500 disabled:cursor-wait disabled:opacity-70 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-500"
                                 >
                                   取消中
                                 </button>
@@ -342,7 +342,7 @@ export function WorkspaceSettingsPanel({
                                 <button
                                   type="button"
                                   disabled
-                                  className="rounded-xl border border-stone-200 bg-white px-3 py-2 text-xs font-bold text-stone-500 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-400"
+                                  className="rounded-xl border border-stone-200 bg-white px-3 py-2 text-xs font-bold text-stone-600 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-400"
                                 >
                                   使用中
                                 </button>
@@ -427,7 +427,7 @@ export function WorkspaceSettingsPanel({
               <>
                 <div className="mb-2">
                   <h3 className="text-2xl font-bold text-stone-900 dark:text-stone-100">对话管理</h3>
-                  <p className="text-[13px] text-stone-500 dark:text-stone-400 mt-2">控制对话流程以及功能，会写入 `settings.toml`。</p>
+                  <p className="text-[13px] text-stone-600 dark:text-stone-400 mt-2">控制对话流程以及功能，会写入 `settings.toml`。</p>
                 </div>
 
                 <WorkspaceSettingRow
@@ -583,11 +583,11 @@ export function WorkspaceSettingsPanel({
                     <div className="w-full min-w-0 max-w-full rounded-2xl border border-stone-200 bg-white px-4 py-3 dark:border-stone-700 dark:bg-stone-900">
                       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <div className="min-w-0">
-                          <p className={`text-sm font-semibold ${hasApiKey ? "text-success" : "text-stone-500 dark:text-stone-400"}`}>
+                          <p className={`text-sm font-semibold ${hasApiKey ? "text-success" : "text-stone-600 dark:text-stone-400"}`}>
                             {hasApiKey ? "已配置" : "未配置"}
                           </p>
                           {apiKeyStatus ? (
-                            <p className="mt-1 max-w-full break-all text-xs text-stone-500 [overflow-wrap:anywhere] dark:text-stone-400">
+                            <p className="mt-1 max-w-full break-all text-xs text-stone-600 [overflow-wrap:anywhere] dark:text-stone-400">
                               当前状态：{apiKeyDisplayValue}
                             </p>
                           ) : null}
@@ -722,7 +722,7 @@ export function WorkspaceSettingsPanel({
               <>
                 <div className="mb-2">
                   <h3 className="text-2xl font-bold text-stone-900 dark:text-stone-100">下载管理</h3>
-                  <p className="text-[13px] text-stone-500 dark:text-stone-400 mt-2">
+                  <p className="text-[13px] text-stone-600 dark:text-stone-400 mt-2">
                     管理内容下载
                   </p>
                 </div>
@@ -747,7 +747,7 @@ export function WorkspaceSettingsPanel({
                 >
                   <div className="w-full flex flex-col gap-3">
                     {ragModelsLoading && !ragModels.length ? (
-                      <div className="flex items-center gap-2 text-sm text-stone-500 dark:text-stone-400">
+                      <div className="flex items-center gap-2 text-sm text-stone-600 dark:text-stone-400">
                         <LoaderCircle size={16} className="animate-spin" />
                         正在读取 RAG 模型状态...
                       </div>
@@ -775,7 +775,7 @@ export function WorkspaceSettingsPanel({
                             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                               <div className="min-w-0">
                                 <strong className="break-words text-sm font-bold text-stone-900 dark:text-stone-100">{model.label}</strong>
-                                <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">{statusText}</p>
+                                <p className="mt-1 text-xs text-stone-600 dark:text-stone-400">{statusText}</p>
                                 {isDownloading ? (
                                   <div className="mt-3 w-full h-1.5 bg-stone-200/70 dark:bg-stone-800 rounded-full overflow-hidden">
                                     <div
@@ -794,7 +794,7 @@ export function WorkspaceSettingsPanel({
                                 <button
                                   type="button"
                                   disabled
-                                  className="rounded-xl border border-stone-200 bg-white px-3 py-2 text-xs font-bold text-stone-400 disabled:cursor-wait disabled:opacity-70 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-500"
+                                  className="rounded-xl border border-stone-200 bg-white px-3 py-2 text-xs font-bold text-stone-500 disabled:cursor-wait disabled:opacity-70 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-500"
                                 >
                                   下载中
                                 </button>
@@ -802,7 +802,7 @@ export function WorkspaceSettingsPanel({
                                 <button
                                   type="button"
                                   disabled
-                                  className="rounded-xl border border-stone-200 bg-white px-3 py-2 text-xs font-bold text-stone-500 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-400"
+                                  className="rounded-xl border border-stone-200 bg-white px-3 py-2 text-xs font-bold text-stone-600 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-400"
                                 >
                                   使用中
                                 </button>
@@ -831,7 +831,7 @@ export function WorkspaceSettingsPanel({
               <>
                 <div className="mb-2">
                   <h3 className="text-2xl font-bold text-stone-900 dark:text-stone-100">外部API</h3>
-                  <p className="text-[13px] text-stone-500 dark:text-stone-400 mt-2">
+                  <p className="text-[13px] text-stone-600 dark:text-stone-400 mt-2">
                     控制外部API的设置。
                   </p>
                 </div>
@@ -883,7 +883,7 @@ export function WorkspaceSettingsPanel({
               className="bg-white dark:bg-neutral-900 border border-stone-200 dark:border-stone-700/60 p-7 rounded-[1.5rem] shadow-[0_20px_40px_rgba(0,0,0,0.15)] max-w-[340px] w-full text-center"
             >
               <h3 className="text-xl font-bold text-stone-900 dark:text-white mb-2">恢复默认设置？</h3>
-              <p className="text-[13px] leading-relaxed text-stone-500 dark:text-stone-400 mb-6">
+              <p className="text-[13px] leading-relaxed text-stone-600 dark:text-stone-400 mb-6">
                 此操作将恢复工作区默认设置，并立即覆盖真实的 <code className="bg-stone-100 dark:bg-stone-800 px-1 py-0.5 rounded text-stone-700 dark:text-stone-300">settings.toml</code>。`.env` 中的模型供应商配置不会被改动。确定继续？
               </p>
               <div className="flex gap-3 justify-center w-full">

--- a/src/frontend/src/features/workspace/ui/WorkspaceToolbar.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceToolbar.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from "react";
 import {
   BookOpenText,
   MessageSquare,
@@ -20,32 +19,13 @@ export function WorkspaceToolbar({
   chatDrawerEnabled = true,
   onOpenUsagePage,
 }) {
-  const settingsButtonRef = useRef(null);
-
-  useEffect(() => {
-    if (!settingsOpen) {
-      return undefined;
-    }
-
-    function handleKeyDown(event) {
-      if (event.key === "Escape") {
-        settingsButtonRef.current?.click();
-      }
-    }
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [settingsOpen]);
-
   return (
     <header className="workspace-toolbar-surface flex justify-between items-center px-6 py-4 border-b border-stone-200/80 dark:border-stone-800 sticky top-0 z-20 shrink-0">
       <div className="flex items-center gap-4">
         {/* Sidebar Toggle */}
         <button
           onClick={onToggleSidebar}
-          className="flex items-center justify-center w-10 h-10 rounded-xl text-stone-500 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800 hover:text-stone-900 dark:hover:text-stone-100 transition-colors mr-2"
+          className="flex items-center justify-center w-10 h-10 rounded-xl text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800 hover:text-stone-900 dark:hover:text-stone-100 transition-colors mr-2"
           aria-label={isSidebarOpen ? "收起文献库" : "展开文献库"}
         >
           {isSidebarOpen ? <PanelLeftClose size={22} /> : <PanelLeftOpen size={22} />}
@@ -62,7 +42,7 @@ export function WorkspaceToolbar({
       </div>
 
       <div className="flex items-center gap-3">
-        <span className="rounded-full border border-stone-200/80 bg-stone-50 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-stone-500 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-400">
+        <span className="rounded-full border border-stone-200/80 bg-stone-50 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-stone-600 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-400">
           Settings
         </span>
         {chatDrawerEnabled ? (
@@ -71,7 +51,7 @@ export function WorkspaceToolbar({
             className={`inline-flex items-center justify-center w-10 h-10 rounded-full transition-colors ${
               chatDrawerOpen
                 ? "bg-stone-200 dark:bg-stone-800 text-stone-900 dark:text-white border border-stone-300 dark:border-stone-700 shadow-sm"
-                : "text-stone-500 dark:text-zinc-400 hover:bg-stone-100 dark:hover:bg-neutral-900 hover:text-stone-900 dark:hover:text-white"
+                : "text-stone-600 dark:text-zinc-400 hover:bg-stone-100 dark:hover:bg-neutral-900 hover:text-stone-900 dark:hover:text-white"
             }`}
             onClick={onToggleChatDrawer}
             title="打开分析助手"
@@ -82,7 +62,7 @@ export function WorkspaceToolbar({
           </button>
         ) : null}
         <button
-          className="inline-flex items-center justify-center w-10 h-10 rounded-full transition-colors hover:bg-stone-100 dark:hover:bg-neutral-900 hover:text-stone-900 dark:hover:text-white text-stone-500 dark:text-zinc-400"
+          className="inline-flex items-center justify-center w-10 h-10 rounded-full transition-colors hover:bg-stone-100 dark:hover:bg-neutral-900 hover:text-stone-900 dark:hover:text-white text-stone-600 dark:text-zinc-400"
           onClick={onOpenUsagePage}
           title="打开用量统计"
           aria-label="打开用量统计"
@@ -90,8 +70,7 @@ export function WorkspaceToolbar({
           <BarChart3 size={18} strokeWidth={2.2} />
         </button>
         <button
-          ref={settingsButtonRef}
-          className={`inline-flex items-center justify-center w-10 h-10 rounded-full transition-colors ${settingsOpen ? "bg-stone-200 dark:bg-stone-800 text-stone-900 dark:text-white border border-stone-300 dark:border-stone-700 shadow-sm" : "text-stone-500 dark:text-zinc-400 hover:bg-stone-100 dark:hover:bg-neutral-900 hover:text-stone-900 dark:hover:text-white"}`}
+          className={`inline-flex items-center justify-center w-10 h-10 rounded-full transition-colors ${settingsOpen ? "bg-stone-200 dark:bg-stone-800 text-stone-900 dark:text-white border border-stone-300 dark:border-stone-700 shadow-sm" : "text-stone-600 dark:text-zinc-400 hover:bg-stone-100 dark:hover:bg-neutral-900 hover:text-stone-900 dark:hover:text-white"}`}
           onClick={onToggleSettingsPanel}
           title="Open Settings"
           aria-label="打开界面设置"

--- a/src/frontend/src/features/workspace/ui/WorkspaceUsagePage.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceUsagePage.jsx
@@ -59,7 +59,7 @@ export function WorkspaceUsagePage({
         </div>
         <button
           type="button"
-          className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-stone-100 dark:bg-stone-800 text-stone-500 hover:bg-stone-200 dark:hover:bg-stone-700 transition-colors shadow-sm"
+          className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-stone-100 dark:bg-stone-800 text-stone-600 hover:bg-stone-200 dark:hover:bg-stone-700 transition-colors shadow-sm"
           onClick={onClose}
           aria-label="关闭面板"
         >
@@ -73,7 +73,7 @@ export function WorkspaceUsagePage({
 
           {/* Range Selector */}
           <div className="flex flex-wrap items-center gap-2 mt-8 mb-6">
-            <span className="text-xs font-semibold text-stone-500 dark:text-stone-400 mr-1">统计范围</span>
+            <span className="text-xs font-semibold text-stone-600 dark:text-stone-400 mr-1">统计范围</span>
             {ranges.map((item) => (
               <button
                 key={item.id}
@@ -91,7 +91,7 @@ export function WorkspaceUsagePage({
 
           {/* Loading / Error */}
           {loading && !usage ? (
-            <div className="flex items-center justify-center gap-3 py-24 text-stone-500 dark:text-stone-400">
+            <div className="flex items-center justify-center gap-3 py-24 text-stone-600 dark:text-stone-400">
               <LoaderCircle size={20} className="animate-spin" />
               <span className="text-sm font-semibold">正在读取用量统计...</span>
             </div>
@@ -135,21 +135,21 @@ export function WorkspaceUsagePage({
                     <div className="flex items-center justify-center w-7 h-7 rounded-lg text-amber-500 bg-amber-500/10 dark:text-amber-400 dark:bg-amber-400/10">
                       <ArrowUpRight size={14} strokeWidth={2.5} />
                     </div>
-                    <span className="text-xs font-semibold text-stone-500 dark:text-stone-400">Prompt / Completion</span>
+                    <span className="text-xs font-semibold text-stone-600 dark:text-stone-400">Prompt / Completion</span>
                   </div>
                   <div className="flex items-baseline gap-3">
                     <div className="min-w-0">
                       <p className={`text-lg font-black tabular-nums text-stone-900 dark:text-stone-100 ${loading ? "opacity-60" : ""}`}>
                         {formatTokenCount(total.promptTokens)}
                       </p>
-                      <p className="text-[10px] font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide">Prompt</p>
+                      <p className="text-[10px] font-semibold text-stone-500 dark:text-stone-500 uppercase tracking-wide">Prompt</p>
                     </div>
                     <span className="text-stone-300 dark:text-stone-700">/</span>
                     <div className="min-w-0">
                       <p className={`text-lg font-black tabular-nums text-stone-900 dark:text-stone-100 ${loading ? "opacity-60" : ""}`}>
                         {formatTokenCount(total.completionTokens)}
                       </p>
-                      <p className="text-[10px] font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide">Completion</p>
+                      <p className="text-[10px] font-semibold text-stone-500 dark:text-stone-500 uppercase tracking-wide">Completion</p>
                     </div>
                   </div>
                 </div>
@@ -170,9 +170,9 @@ export function WorkspaceUsagePage({
               {/* ── Providers & Models ── */}
               <motion.div variants={fadeUpVariant}>
                 <h3 className="text-sm font-bold text-stone-900 dark:text-stone-100 mb-3 flex items-center gap-2">
-                  <Server size={14} strokeWidth={2.5} className="text-stone-400" />
+                  <Server size={14} strokeWidth={2.5} className="text-stone-500" />
                   供应商与模型
-                  <span className="text-[11px] font-semibold text-stone-400 dark:text-stone-500">({providers.length})</span>
+                  <span className="text-[11px] font-semibold text-stone-500 dark:text-stone-500">({providers.length})</span>
                 </h3>
                 {providers.length ? (
                   <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
@@ -186,7 +186,7 @@ export function WorkspaceUsagePage({
                             <p className="truncate text-sm font-bold text-stone-800 dark:text-stone-200">
                               {item.provider} · {item.model}
                             </p>
-                            <p className="mt-0.5 truncate text-[11px] text-stone-500 dark:text-stone-500">
+                            <p className="mt-0.5 truncate text-[11px] text-stone-600 dark:text-stone-500">
                               {item.baseUrl || "默认接口"}
                             </p>
                           </div>
@@ -203,7 +203,7 @@ export function WorkspaceUsagePage({
                             />
                           </div>
                         )}
-                        <div className="flex items-center gap-4 mt-2 text-[11px] text-stone-500 dark:text-stone-400">
+                        <div className="flex items-center gap-4 mt-2 text-[11px] text-stone-600 dark:text-stone-400">
                           <span className="flex items-center gap-1">
                             <ArrowUpRight size={10} strokeWidth={2.5} />
                             Prompt {formatTokenCount(item.promptTokens)}
@@ -217,7 +217,7 @@ export function WorkspaceUsagePage({
                     ))}
                   </div>
                 ) : (
-                  <div className="rounded-2xl border border-dashed border-stone-200 px-4 py-6 text-center text-sm text-stone-500 dark:border-stone-800 dark:text-stone-400">
+                  <div className="rounded-2xl border border-dashed border-stone-200 px-4 py-6 text-center text-sm text-stone-600 dark:border-stone-800 dark:text-stone-400">
                     暂无真实 token 用量记录。
                   </div>
                 )}
@@ -226,9 +226,9 @@ export function WorkspaceUsagePage({
               {/* ── Recent Records Table ── */}
               <motion.div variants={fadeUpVariant}>
                 <h3 className="text-sm font-bold text-stone-900 dark:text-stone-100 mb-3 flex items-center gap-2">
-                  <Clock size={14} strokeWidth={2.5} className="text-stone-400" />
+                  <Clock size={14} strokeWidth={2.5} className="text-stone-500" />
                   最近调用记录
-                  <span className="text-[11px] font-semibold text-stone-400 dark:text-stone-500">({recent.length})</span>
+                  <span className="text-[11px] font-semibold text-stone-500 dark:text-stone-500">({recent.length})</span>
                 </h3>
                 {recent.length ? (
                   <div className={`overflow-hidden rounded-2xl border border-stone-200 transition-opacity dark:border-stone-800 ${loading ? "opacity-60" : ""}`}>
@@ -236,12 +236,12 @@ export function WorkspaceUsagePage({
                       <table className="w-full text-left">
                         <thead>
                           <tr className="border-b border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-900/50">
-                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-500 dark:text-stone-400 uppercase tracking-wider">时间</th>
-                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-500 dark:text-stone-400 uppercase tracking-wider">类别</th>
-                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-500 dark:text-stone-400 uppercase tracking-wider">供应商 · 模型</th>
-                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-500 dark:text-stone-400 uppercase tracking-wider text-right">Prompt</th>
-                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-500 dark:text-stone-400 uppercase tracking-wider text-right">Completion</th>
-                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-500 dark:text-stone-400 uppercase tracking-wider text-right">Total</th>
+                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-600 dark:text-stone-400 uppercase tracking-wider">时间</th>
+                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-600 dark:text-stone-400 uppercase tracking-wider">类别</th>
+                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-600 dark:text-stone-400 uppercase tracking-wider">供应商 · 模型</th>
+                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-600 dark:text-stone-400 uppercase tracking-wider text-right">Prompt</th>
+                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-600 dark:text-stone-400 uppercase tracking-wider text-right">Completion</th>
+                            <th className="px-4 py-2.5 text-[11px] font-bold text-stone-600 dark:text-stone-400 uppercase tracking-wider text-right">Total</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -281,7 +281,7 @@ export function WorkspaceUsagePage({
                     </div>
                   </div>
                 ) : (
-                  <div className="rounded-2xl border border-dashed border-stone-200 px-4 py-6 text-center text-sm text-stone-500 dark:border-stone-800 dark:text-stone-400">
+                  <div className="rounded-2xl border border-dashed border-stone-200 px-4 py-6 text-center text-sm text-stone-600 dark:border-stone-800 dark:text-stone-400">
                     暂无最近记录。
                   </div>
                 )}
@@ -304,7 +304,7 @@ function UsageStatCard({ label, value, icon: Icon, accentClass, large = false, l
         <div className={`flex items-center justify-center w-7 h-7 rounded-lg ${accentClass}`}>
           <Icon size={14} strokeWidth={2.5} />
         </div>
-        <span className="text-xs font-semibold text-stone-500 dark:text-stone-400">{label}</span>
+        <span className="text-xs font-semibold text-stone-600 dark:text-stone-400">{label}</span>
       </div>
       <p className={`text-2xl font-black tabular-nums text-stone-900 dark:text-stone-100 transition-opacity ${loading ? "opacity-60" : ""}`}>
         {formatTokenCount(value)}
@@ -424,11 +424,11 @@ function UsageBarChart({ timeline, granularity, range, loading = false }) {
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h4 className="text-sm font-bold text-stone-900 dark:text-stone-100">Token 用量趋势</h4>
-          <p className="mt-1 text-xs font-semibold text-stone-500 dark:text-stone-400">
+          <p className="mt-1 text-xs font-semibold text-stone-600 dark:text-stone-400">
             按时间聚合真实 token 消耗，悬停查看明细。
           </p>
         </div>
-        <div className="flex items-center gap-3 text-[11px] font-bold text-stone-500 dark:text-stone-400">
+        <div className="flex items-center gap-3 text-[11px] font-bold text-stone-600 dark:text-stone-400">
           <span className="flex items-center gap-1.5">
             <span className="inline-block h-2.5 w-2.5 rounded-full bg-indigo-500 shadow-[0_0_0_3px_rgba(99,102,241,0.12)]" />
             生成

--- a/src/frontend/src/features/workspace/ui/WorkspaceVideoPlayer.jsx
+++ b/src/frontend/src/features/workspace/ui/WorkspaceVideoPlayer.jsx
@@ -39,7 +39,7 @@ export function WorkspaceVideoPlayer({ videoSource, playerSeekRequest, videoSour
   return (
     <div className="flex flex-col gap-4">
       <div className="workspace-muted-panel rounded-3xl border p-4">
-        <p className="mb-2 text-xs font-bold uppercase text-stone-500 dark:text-stone-400">Media Preview</p>
+        <p className="mb-2 text-xs font-bold uppercase text-stone-600 dark:text-stone-400">Media Preview</p>
         {playerSeekRequest ? (
           <div className="mt-3 rounded-2xl border border-info/20 bg-info-subtle px-4 py-3 text-sm text-stone-800 dark:text-stone-100">
             <p className="font-semibold">

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceConfirmDialog.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceConfirmDialog.jsx
@@ -46,7 +46,7 @@ export function WorkspaceConfirmDialog({
             </div>
             <div className="min-w-0">
               <h3 className="text-lg font-bold text-stone-900 dark:text-stone-100">{title}</h3>
-              <p className="mt-2 text-sm leading-relaxed text-stone-500 dark:text-stone-400">{description}</p>
+              <p className="mt-2 text-sm leading-relaxed text-stone-600 dark:text-stone-400">{description}</p>
             </div>
           </div>
 

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceMarkdownMessage.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceMarkdownMessage.jsx
@@ -183,10 +183,10 @@ function CitationPreviewCard({ preview, position }) {
     >
       <span className="block font-semibold text-stone-900 dark:text-stone-100">{preview.title}</span>
       {preview.sourceType ? (
-        <span className="mt-1 block text-[11px] uppercase tracking-wide text-stone-400 dark:text-stone-500">{preview.sourceType}</span>
+        <span className="mt-1 block text-[11px] uppercase tracking-wide text-stone-500 dark:text-stone-500">{preview.sourceType}</span>
       ) : null}
       {preview.detail ? (
-        <span className="mt-2 block text-[11px] text-stone-500 dark:text-stone-400">{preview.detail}</span>
+        <span className="mt-2 block text-[11px] text-stone-600 dark:text-stone-400">{preview.detail}</span>
       ) : null}
       {preview.text ? (
         <span className="mt-2 block leading-relaxed text-stone-600 dark:text-stone-300">{preview.text}</span>
@@ -247,7 +247,7 @@ function ThinkBlock({ content }) {
         type="button"
         aria-expanded={expanded}
         onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center justify-between text-left text-xs font-bold uppercase tracking-wide text-stone-500 dark:text-stone-400"
+        className="flex w-full items-center justify-between text-left text-xs font-bold uppercase tracking-wide text-stone-600 dark:text-stone-400"
       >
         思考过程
         <span aria-hidden="true">{expanded ? "收起" : "展开"}</span>

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceMetricCard.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceMetricCard.jsx
@@ -21,7 +21,7 @@ export function WorkspaceMetricCard({
             ? "text-stone-700 dark:text-zinc-300"
             : accent === "info"
               ? "text-info"
-              : "text-stone-500 dark:text-stone-400"
+              : "text-stone-600 dark:text-stone-400"
         } ${labelClassName}`.trim()}
       >
         {label}

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceSettingsControls.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceSettingsControls.jsx
@@ -31,7 +31,7 @@ export function WorkspaceProviderSelect({ value, onChange, options, className = 
         className="flex w-full items-center justify-between gap-2 rounded-xl border border-stone-200 bg-white px-4 py-2.5 text-left text-sm text-stone-900 outline-none transition-colors hover:border-accent/50 focus:border-accent dark:border-stone-700 dark:bg-stone-900 dark:text-stone-100"
       >
         <span className="truncate font-medium">{selected?.label ?? value}</span>
-        <ChevronDown size={15} className={`shrink-0 text-stone-400 transition-transform ${open ? "rotate-180" : ""}`} />
+        <ChevronDown size={15} className={`shrink-0 text-stone-500 transition-transform ${open ? "rotate-180" : ""}`} />
       </button>
 
       {open && (
@@ -39,7 +39,7 @@ export function WorkspaceProviderSelect({ value, onChange, options, className = 
           {groups.map((group, gi) => (
             <div key={group}>
               {gi > 0 && <div className="mx-3 border-t border-stone-100 dark:border-stone-800" />}
-              <div className="px-4 pb-1 pt-3 text-[10px] font-bold uppercase tracking-widest text-stone-400 dark:text-stone-500">
+              <div className="px-4 pb-1 pt-3 text-[10px] font-bold uppercase tracking-widest text-stone-500 dark:text-stone-500">
                 {group}
               </div>
               {groupMap[group].map((option) => {
@@ -56,7 +56,7 @@ export function WorkspaceProviderSelect({ value, onChange, options, className = 
                         {option.label}
                       </div>
                       {option.description && (
-                        <div className="mt-0.5 text-xs leading-snug text-stone-400 dark:text-stone-500">
+                        <div className="mt-0.5 text-xs leading-snug text-stone-500 dark:text-stone-500">
                           {option.description}
                         </div>
                       )}
@@ -80,7 +80,7 @@ export function WorkspaceSettingRow({ title, description, children, contentClass
     <div className="flex flex-col justify-between gap-6 rounded-[1.5rem] border border-stone-100 bg-stone-50/50 p-6 transition-colors dark:border-stone-800/60 dark:bg-stone-800/30 2xl:flex-row 2xl:items-center">
       <div className="min-w-0 max-w-none 2xl:w-[260px] 2xl:shrink-0">
         <strong className="mb-1.5 block text-base font-bold text-stone-900 dark:text-stone-100">{title}</strong>
-        <span className="block text-[13px] leading-relaxed text-stone-500 dark:text-stone-400">{description}</span>
+        <span className="block text-[13px] leading-relaxed text-stone-600 dark:text-stone-400">{description}</span>
       </div>
       <div className={`flex min-w-0 w-full items-center justify-end ${contentLayoutClassName}`}>{children}</div>
     </div>
@@ -119,7 +119,7 @@ export function WorkspaceSegmentedControl({ value, options, onChange }) {
             className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
               active
                 ? "bg-white text-stone-900 shadow-sm dark:bg-stone-700 dark:text-stone-100"
-                : "text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200"
+                : "text-stone-600 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200"
             }`}
             onClick={() => onChange(option.id)}
           >

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceStateBlock.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceStateBlock.jsx
@@ -30,11 +30,11 @@ export function WorkspaceStateBlock({
           </div>
         ) : null}
         {eyebrow ? (
-          <p className="text-xs font-bold uppercase tracking-widest text-stone-500 dark:text-stone-400">{eyebrow}</p>
+          <p className="text-xs font-bold uppercase tracking-widest text-stone-600 dark:text-stone-400">{eyebrow}</p>
         ) : null}
         <h3 className="mt-3 text-2xl font-bold text-stone-900 dark:text-stone-100">{title}</h3>
         {description ? (
-          <p className="mt-3 text-sm leading-relaxed text-stone-500 dark:text-stone-400">{description}</p>
+          <p className="mt-3 text-sm leading-relaxed text-stone-600 dark:text-stone-400">{description}</p>
         ) : null}
         {children ? <div className="mt-5">{children}</div> : null}
       </div>

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceToolGrid.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceToolGrid.jsx
@@ -23,7 +23,7 @@ export function WorkspaceToolGrid({ items, onSelect }) {
                 </span>
                 <span className="flex min-w-0 flex-col">
                   <span className="text-base font-bold">{meta.label}</span>
-                  <span className="mt-1 text-xs text-stone-500 dark:text-stone-400">{meta.description}</span>
+                  <span className="mt-1 text-xs text-stone-600 dark:text-stone-400">{meta.description}</span>
                   {hint ? <span className="mt-3 text-xs font-semibold text-stone-600 dark:text-stone-300">{hint}</span> : null}
                 </span>
               </div>

--- a/src/frontend/src/features/workspace/ui/shared/WorkspaceToolHeader.jsx
+++ b/src/frontend/src/features/workspace/ui/shared/WorkspaceToolHeader.jsx
@@ -5,9 +5,9 @@ export function WorkspaceToolHeader({ meta, onBack, backLabel = "返回工具页
   return (
     <div className="flex items-start justify-between gap-4">
       <div>
-        <p className="text-xs font-bold text-stone-500 dark:text-stone-400 uppercase mb-1">Tool Page</p>
+        <p className="text-xs font-bold text-stone-600 dark:text-stone-400 uppercase mb-1">Tool Page</p>
         <h2 className="text-2xl font-bold text-stone-900 dark:text-stone-100 leading-snug">{meta?.label}</h2>
-        <p className="mt-2 text-sm text-stone-500 dark:text-stone-400">{meta?.description}</p>
+        <p className="mt-2 text-sm text-stone-600 dark:text-stone-400">{meta?.description}</p>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {exportActions.length ? <WorkspaceExportMenu exportActions={exportActions} /> : null}
@@ -51,7 +51,7 @@ export function WorkspaceExportMenu({ exportActions, buttonLabel = "导出" }) {
         type="button"
         disabled
         title={disabledReason}
-        className={`${className} cursor-not-allowed text-stone-400 opacity-50 dark:text-stone-500`}
+        className={`${className} cursor-not-allowed text-stone-500 opacity-50 dark:text-stone-500`}
       >
         <Download size={16} />
         {buttonLabel}
@@ -90,7 +90,7 @@ export function WorkspaceExportMenu({ exportActions, buttonLabel = "导出" }) {
               type="button"
               disabled
               title={action.disabledReason ?? "当前内容不可导出"}
-              className="flex w-full cursor-not-allowed items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-semibold text-stone-400 opacity-60 dark:text-stone-500"
+              className="flex w-full cursor-not-allowed items-center gap-2 rounded-xl px-3 py-2 text-left text-sm font-semibold text-stone-500 opacity-60 dark:text-stone-500"
             >
               <Download size={15} />
               {action.label ?? "导出 MD"}

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceChatManagementView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceChatManagementView.jsx
@@ -35,13 +35,13 @@ export function WorkspaceChatManagementView({ chat }) {
       </div>
 
       <div>
-        <h3 className="text-sm font-bold uppercase tracking-widest text-stone-400 dark:text-stone-500 mb-5 flex items-center gap-2">
+        <h3 className="text-sm font-bold uppercase tracking-widest text-stone-500 dark:text-stone-500 mb-5 flex items-center gap-2">
           <Clock3 size={16} /> 历史记录 ({sessions.length})
         </h3>
         {sessions.length === 0 ? (
           <div className="rounded-3xl border border-dashed border-stone-200/80 bg-stone-50/50 p-12 text-center dark:border-stone-800 dark:bg-stone-950/30">
             <MessageSquare size={32} className="mx-auto mb-3 text-stone-300 dark:text-stone-700" />
-            <p className="text-stone-500 dark:text-stone-400 font-medium">暂无历史对话记录</p>
+            <p className="text-stone-600 dark:text-stone-400 font-medium">暂无历史对话记录</p>
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-4">
@@ -58,7 +58,7 @@ export function WorkspaceChatManagementView({ chat }) {
                 <div className="flex items-center justify-between w-full">
                   <div className={`flex h-10 w-10 items-center justify-center rounded-2xl ${session.id === activeSessionId
                       ? "bg-accent/15 text-accent"
-                      : "bg-stone-100 text-stone-500 dark:bg-stone-800 dark:text-stone-400 group-hover:bg-accent/10 group-hover:text-accent"
+                      : "bg-stone-100 text-stone-600 dark:bg-stone-800 dark:text-stone-400 group-hover:bg-accent/10 group-hover:text-accent"
                     } transition-colors`}>
                     <MessageSquare size={18} />
                   </div>

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceKnowledgeCardsView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceKnowledgeCardsView.jsx
@@ -67,7 +67,7 @@ export function WorkspaceKnowledgeCardsView({
         <div className="mt-6 h-2 overflow-hidden rounded-full bg-stone-200/80 dark:bg-stone-800">
           <div className="h-full w-1/2 animate-pulse rounded-full bg-accent" />
         </div>
-        <p className="mt-3 text-xs text-stone-500 dark:text-stone-400">生成完成后会自动展示结果。</p>
+        <p className="mt-3 text-xs text-stone-600 dark:text-stone-400">生成完成后会自动展示结果。</p>
       </WorkspaceStateBlock>
     );
   }
@@ -136,7 +136,7 @@ export function WorkspaceKnowledgeCardsView({
           >
             <div className="flex items-start justify-between gap-3">
               <div>
-                <p className="text-[10px] font-bold uppercase tracking-widest text-stone-500 dark:text-stone-400">{card.kind}</p>
+                <p className="text-[10px] font-bold uppercase tracking-widest text-stone-600 dark:text-stone-400">{card.kind}</p>
                 <h3 className="mt-2 text-lg font-bold text-stone-900 dark:text-stone-100">{card.title}</h3>
               </div>
               <CopyToClipboardButton text={buildCardMarkdown(card)} className="shrink-0" />

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceMindmapView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceMindmapView.jsx
@@ -57,7 +57,7 @@ export function WorkspaceMindmapView({
           disabled={isGeneratingMindmapSelectedVideo}
           className={`inline-flex items-center gap-2 rounded-2xl px-5 py-3 text-sm font-semibold transition-all ${
             isGeneratingMindmapSelectedVideo
-              ? "motion-busy-button cursor-not-allowed bg-stone-200 text-stone-500"
+              ? "motion-busy-button cursor-not-allowed bg-stone-200 text-stone-600"
               : "bg-accent text-white shadow-sm hover:bg-accent/90"
           }`}
         >

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceNotesView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceNotesView.jsx
@@ -100,7 +100,7 @@ export function WorkspaceNotesView({
           >
             <ChevronLeft size={16} /> 返回列表
           </button>
-          <h2 className="text-sm font-bold tracking-widest text-stone-400 uppercase dark:text-stone-500">新建笔记</h2>
+          <h2 className="text-sm font-bold tracking-widest text-stone-500 uppercase dark:text-stone-500">新建笔记</h2>
           <div className="w-[88px]" /> {/* 占位符以居中标题 */}
         </div>
         
@@ -166,7 +166,7 @@ export function WorkspaceNotesView({
               <>
                 <button
                   onClick={handleStartEdit}
-                  className="flex h-8 w-8 items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-900 dark:text-stone-400 dark:hover:bg-stone-800 dark:hover:text-stone-100"
+                  className="flex h-8 w-8 items-center justify-center rounded-full text-stone-600 hover:bg-stone-100 hover:text-stone-900 dark:text-stone-400 dark:hover:bg-stone-800 dark:hover:text-stone-100"
                   title="编辑"
                 >
                   <PencilLine size={15} />
@@ -174,7 +174,7 @@ export function WorkspaceNotesView({
                 <button
                   onClick={() => handleDeleteNote(selectedNote.id)}
                   disabled={savingNote}
-                  className="flex h-8 w-8 items-center justify-center rounded-full text-stone-500 hover:bg-danger-subtle hover:text-danger dark:text-stone-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-full text-stone-600 hover:bg-danger-subtle hover:text-danger dark:text-stone-400"
                   title="删除"
                 >
                   <Trash2 size={15} />
@@ -206,7 +206,7 @@ export function WorkspaceNotesView({
                 <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider ${selectedNote.source === "agent" ? "bg-info-subtle text-info" : "bg-stone-100 text-stone-600 dark:bg-stone-800 dark:text-stone-300"}`}>
                   {selectedNote.source === "agent" ? "🤖 Agent Note" : "✍️ Manual Note"}
                 </span>
-                <span className="text-xs font-medium text-stone-400 dark:text-stone-500">
+                <span className="text-xs font-medium text-stone-500 dark:text-stone-500">
                   {selectedNote.createdAt.replace("T", " ").replace("Z", "").substring(0, 16)}
                   {selectedNote.updatedAt !== selectedNote.createdAt && " (已编辑)"}
                 </span>
@@ -229,7 +229,7 @@ export function WorkspaceNotesView({
       <div className="flex items-center justify-between px-2">
         <div>
           <h2 className="text-lg font-bold text-stone-900 dark:text-stone-100">全部笔记</h2>
-          <p className="mt-0.5 text-xs text-stone-500 dark:text-stone-400">共 {notes?.notes?.length || 0} 条记录</p>
+          <p className="mt-0.5 text-xs text-stone-600 dark:text-stone-400">共 {notes?.notes?.length || 0} 条记录</p>
         </div>
         <button 
           onClick={() => setViewState("create")} 
@@ -253,10 +253,10 @@ export function WorkspaceNotesView({
                   {note.source === "agent" ? "🤖 Agent" : "✍️ Manual"}
                 </span>
               </div>
-              <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-stone-500 dark:text-stone-400">
+              <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-stone-600 dark:text-stone-400">
                 {note.content}
               </p>
-              <div className="mt-4 flex items-center text-xs font-medium text-stone-400 dark:text-stone-500">
+              <div className="mt-4 flex items-center text-xs font-medium text-stone-500 dark:text-stone-500">
                 <Calendar size={12} className="mr-1.5" />
                 {note.createdAt.replace("T", " ").substring(0, 16)}
               </div>

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceOverviewView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceOverviewView.jsx
@@ -74,7 +74,7 @@ export function WorkspaceOverviewView({
         <div className="absolute top-0 right-0 p-4 opacity-10">
           <Sparkles size={64} />
         </div>
-        <p className="relative z-10 mb-3 text-[10px] font-bold uppercase tracking-widest text-stone-500 dark:text-stone-400">
+        <p className="relative z-10 mb-3 text-[10px] font-bold uppercase tracking-widest text-stone-600 dark:text-stone-400">
           Core Problem
         </p>
         <p className="relative z-10 text-base font-medium leading-relaxed">
@@ -121,7 +121,7 @@ export function WorkspaceOverviewView({
                 <p className="mb-1.5 text-xs font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-400">Chapter {index + 1}</p>
                 <h3 className="text-lg font-bold leading-tight text-stone-900 dark:text-stone-100">{chapter.title}</h3>
               </div>
-              <span className="shrink-0 rounded-lg bg-stone-100 px-2 py-1 text-xs font-mono font-bold text-stone-500 dark:bg-stone-900 dark:text-stone-400">
+              <span className="shrink-0 rounded-lg bg-stone-100 px-2 py-1 text-xs font-mono font-bold text-stone-600 dark:bg-stone-900 dark:text-stone-400">
                 {formatRange(chapter.start_seconds, chapter.end_seconds)}
               </span>
             </button>
@@ -146,10 +146,10 @@ export function WorkspaceOverviewView({
                     </span>
                     <div>
                       <p className="text-sm font-semibold text-stone-900 dark:text-stone-100">查看本章原文</p>
-                      <p className="text-xs text-stone-500 dark:text-stone-400">{chapter.transcript_segments.length} 段转写</p>
+                      <p className="text-xs text-stone-600 dark:text-stone-400">{chapter.transcript_segments.length} 段转写</p>
                     </div>
                   </div>
-                  <span className="text-xs font-semibold text-stone-500 dark:text-stone-400">
+                  <span className="text-xs font-semibold text-stone-600 dark:text-stone-400">
                     {formatRange(chapter.start_seconds, chapter.end_seconds)}
                   </span>
                 </summary>
@@ -167,7 +167,7 @@ export function WorkspaceOverviewView({
                         })}
                         className="block w-full rounded-2xl bg-white/90 px-3 py-3 text-left transition-colors hover:bg-accent/5 dark:bg-neutral-900 dark:hover:bg-accent/10"
                       >
-                        <p className="text-[11px] font-bold uppercase tracking-widest text-stone-500 dark:text-stone-400">
+                        <p className="text-[11px] font-bold uppercase tracking-widest text-stone-600 dark:text-stone-400">
                           {formatTimestamp(segment.start_seconds)} - {formatTimestamp(segment.end_seconds)}
                         </p>
                         <p className="mt-2 text-sm leading-relaxed text-stone-700 dark:text-stone-300">{segment.text}</p>

--- a/src/frontend/src/features/workspace/ui/views/WorkspacePreviewView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspacePreviewView.jsx
@@ -37,7 +37,7 @@ export function WorkspacePreviewView({ previewSource, previewSeekRequest }) {
   return (
     <div className="flex flex-col gap-4">
       <div className="workspace-muted-panel rounded-3xl border p-4">
-        <p className="mb-2 text-xs font-bold uppercase text-stone-500 dark:text-stone-400">Media Preview</p>
+        <p className="mb-2 text-xs font-bold uppercase text-stone-600 dark:text-stone-400">Media Preview</p>
         {previewSeekRequest ? (
           <div className="mt-3 rounded-2xl border border-info/20 bg-info-subtle px-4 py-3 text-sm text-stone-800 dark:text-stone-100">
             <p className="font-semibold">

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceSeriesHomeView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceSeriesHomeView.jsx
@@ -10,7 +10,7 @@ export function WorkspaceSeriesHomeView({ activeSeries }) {
       <div className="workspace-panel rounded-[1.5rem] border p-5 shadow-sm">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
-            <span className="text-[11px] font-bold uppercase tracking-widest text-stone-500 dark:text-zinc-500">转化进度</span>
+            <span className="text-[11px] font-bold uppercase tracking-widest text-stone-600 dark:text-zinc-500">转化进度</span>
             <span className="px-2.5 py-1 rounded-full bg-stone-100 dark:bg-neutral-900 border border-stone-200/50 dark:border-white/5 text-[10px] font-bold text-stone-600 dark:text-zinc-400">
               {processedSeriesVideos.length} / {seriesVideos.length} 视频
             </span>

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceSeriesMindmapView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceSeriesMindmapView.jsx
@@ -65,7 +65,7 @@ export function WorkspaceSeriesMindmapView({
           disabled={generatingSeriesMindmap}
           className={`inline-flex items-center gap-2 rounded-2xl px-5 py-3 text-sm font-semibold transition-all ${
             generatingSeriesMindmap
-              ? "motion-busy-button cursor-not-allowed bg-stone-200 text-stone-500"
+              ? "motion-busy-button cursor-not-allowed bg-stone-200 text-stone-600"
               : "bg-accent text-white shadow-sm hover:bg-accent/90"
           }`}
         >

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceSeriesOverviewView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceSeriesOverviewView.jsx
@@ -4,7 +4,7 @@ export function WorkspaceSeriesOverviewView({ activeSeries }) {
   return (
     <div className="w-full max-w-4xl">
       <article className="workspace-muted-panel rounded-[2rem] border p-7">
-        <p className="text-xs font-bold uppercase tracking-widest text-stone-500 dark:text-stone-400">Series Overview</p>
+        <p className="text-xs font-bold uppercase tracking-widest text-stone-600 dark:text-stone-400">Series Overview</p>
         <h3 className="mt-3 text-3xl font-bold text-stone-900 dark:text-stone-100">{activeSeries.title}</h3>
         <p className="mt-4 text-sm leading-relaxed text-stone-600 dark:text-stone-400">
           这是系列级上下文。后续 AI 可以基于整个 series 理解主题范围、视频分布和知识覆盖，而不是被锁定在单一视频上。
@@ -14,7 +14,7 @@ export function WorkspaceSeriesOverviewView({ activeSeries }) {
             <div key={video.id} className="workspace-elevated-panel rounded-2xl border px-4 py-3">
               <div className="flex items-center justify-between gap-3">
                 <strong className="text-sm font-semibold text-stone-900 dark:text-stone-100">{video.title}</strong>
-                <span className={`text-xs font-semibold ${video.processed ? "text-accent dark:text-accent" : "text-stone-500"}`}>
+                <span className={`text-xs font-semibold ${video.processed ? "text-accent dark:text-accent" : "text-stone-600"}`}>
                   {video.processed ? "已处理" : "未处理"}
                 </span>
               </div>

--- a/src/frontend/src/features/workspace/ui/views/WorkspaceSeriesProgressView.jsx
+++ b/src/frontend/src/features/workspace/ui/views/WorkspaceSeriesProgressView.jsx
@@ -4,20 +4,20 @@ export function WorkspaceSeriesProgressView({ activeSeries }) {
   return (
     <div className="w-full max-w-4xl">
       <article className="workspace-muted-panel rounded-[2rem] border p-7">
-        <p className="text-xs font-bold uppercase tracking-widest text-stone-500 dark:text-stone-400">Series Progress</p>
+        <p className="text-xs font-bold uppercase tracking-widest text-stone-600 dark:text-stone-400">Series Progress</p>
         <h3 className="mt-3 text-3xl font-bold text-stone-900 dark:text-stone-100">处理进度</h3>
         <div className="mt-6 flex flex-col gap-3">
           {seriesVideos.map((video, index) => (
             <div key={video.id} className="workspace-elevated-panel rounded-2xl border px-4 py-4">
               <div className="flex items-center justify-between gap-4">
                 <div>
-                  <p className="text-xs font-bold uppercase tracking-widest text-stone-400 dark:text-stone-500">Video {index + 1}</p>
+                  <p className="text-xs font-bold uppercase tracking-widest text-stone-500 dark:text-stone-500">Video {index + 1}</p>
                   <strong className="mt-1 block text-sm font-semibold text-stone-900 dark:text-stone-100">{video.title}</strong>
                 </div>
                 <span className={`rounded-full px-3 py-1 text-xs font-semibold ${
                   video.processed
                     ? "bg-stone-100 text-stone-900 dark:bg-neutral-900 dark:text-white border border-stone-200 dark:border-white/10"
-                    : "bg-stone-100 text-stone-500 dark:bg-stone-800 dark:text-stone-300"
+                    : "bg-stone-100 text-stone-600 dark:bg-stone-800 dark:text-stone-300"
                 }`}>
                   {video.processed ? "已完成" : "待处理"}
                 </span>

--- a/src/frontend/src/features/workspace/ui/workspacePageModel.js
+++ b/src/frontend/src/features/workspace/ui/workspacePageModel.js
@@ -128,6 +128,7 @@ export function buildWorkspacePageModel(controller) {
       resetSettings: controller.onResetSettings,
       clearError: controller.onClearError,
       resolveLinkedSeries: controller.onResolveLinkedSeries,
+      selectLocalMedia: controller.onSelectLocalMedia,
       resolvePlaygroundVideo: controller.onResolvePlaygroundVideo,
       resolveSeriesVideo: controller.onResolveSeriesVideo,
       initBilibiliCookie: controller.onInitBilibiliCookie,

--- a/src/frontend/src/features/workspace/ui/workspaceToolMeta.js
+++ b/src/frontend/src/features/workspace/ui/workspaceToolMeta.js
@@ -9,54 +9,58 @@ import {
   MessageSquare,
 } from "lucide-react";
 
+/**
+ * Shared visual styling for every tool tile.
+ *
+ * Previously each of the 8 tiles repeated the same `palette` / `iconShell` /
+ * `arrowShell` strings verbatim (~1.4 KB of duplication). They are now sourced
+ * from a single object so the look-and-feel of tool tiles can be tuned in one
+ * place. Tile entries only declare their semantic identity (label/description/icon).
+ */
+const SHARED_TOOL_VISUALS = {
+  palette:
+    "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
+  iconShell: "bg-accent/10 text-accent border border-accent/20",
+  arrowShell:
+    "bg-stone-50 text-stone-500 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+};
+
 export const TOOL_TILES = {
   "chat-management": {
     label: "对话管理",
     description: "用于切换会话记录",
     icon: MessageSquare,
-    palette: "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
-    iconShell: "bg-accent/10 text-accent border border-accent/20",
-    arrowShell: "bg-stone-50 text-stone-400 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+    ...SHARED_TOOL_VISUALS,
   },
   overview: {
     label: "AI概况",
     description: "章节与关键结论",
     icon: FileText,
-    palette: "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
-    iconShell: "bg-accent/10 text-accent border border-accent/20",
-    arrowShell: "bg-stone-50 text-stone-400 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+    ...SHARED_TOOL_VISUALS,
   },
   mindmap: {
     label: "思维导图(beta)",
     description: "结构化知识图谱",
     icon: Network,
-    palette: "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
-    iconShell: "bg-accent/10 text-accent border border-accent/20",
-    arrowShell: "bg-stone-50 text-stone-400 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+    ...SHARED_TOOL_VISUALS,
   },
   "knowledge-cards": {
     label: "知识卡片(beta)",
     description: "原子知识、标签与来源锚点",
     icon: BrainCircuit,
-    palette: "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
-    iconShell: "bg-accent/10 text-accent border border-accent/20",
-    arrowShell: "bg-stone-50 text-stone-400 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+    ...SHARED_TOOL_VISUALS,
   },
   notes: {
     label: "笔记",
     description: "手记与 Agent 记录",
     icon: StickyNote,
-    palette: "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
-    iconShell: "bg-accent/10 text-accent border border-accent/20",
-    arrowShell: "bg-stone-50 text-stone-400 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+    ...SHARED_TOOL_VISUALS,
   },
   preview: {
     label: "视频预览",
     description: "查看原始视频内容",
     icon: PlaySquare,
-    palette: "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
-    iconShell: "bg-accent/10 text-accent border border-accent/20",
-    arrowShell: "bg-stone-50 text-stone-400 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+    ...SHARED_TOOL_VISUALS,
   },
 };
 
@@ -65,17 +69,13 @@ export const SERIES_TOOL_TILES = {
     label: "对话管理",
     description: "用于切换会话记录",
     icon: MessageSquare,
-    palette: "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
-    iconShell: "bg-accent/10 text-accent border border-accent/20",
-    arrowShell: "bg-stone-50 text-stone-400 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+    ...SHARED_TOOL_VISUALS,
   },
   "series-mindmap": {
     label: "全局思维导图",
     description: "结构化展现系列知识脉络 (暂未实现)",
     icon: Network,
-    palette: "workspace-panel border hover:shadow-lg hover:-translate-y-0.5 hover:bg-accent/5 dark:hover:bg-accent/10 hover:border-accent/30 transition-all",
-    iconShell: "bg-accent/10 text-accent border border-accent/20",
-    arrowShell: "bg-stone-50 text-stone-400 dark:bg-neutral-900/50 dark:text-zinc-500 border border-stone-200/50 dark:border-white/5 group-hover:bg-accent group-hover:text-white group-hover:border-accent/80",
+    ...SHARED_TOOL_VISUALS,
   },
 };
 

--- a/src/frontend/src/shared/lib/useFocusTrap.js
+++ b/src/frontend/src/shared/lib/useFocusTrap.js
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * Trap keyboard focus inside `containerRef` while `active` is true.
+ *
+ * Behavior:
+ *  - On activate: remembers the currently-focused element (the trigger) and
+ *    moves focus to the first focusable child of the container.
+ *  - Tab / Shift+Tab cycle within the container (WCAG 2.4.3 Focus Order).
+ *  - On deactivate: restores focus to the trigger (WCAG 2.4.11).
+ *
+ * The consumer is responsible for closing the dialog on Escape (e.g. via an
+ * `onKeyDown` handler on the same container) — this hook only manages focus.
+ *
+ * @param {React.RefObject<HTMLElement>} containerRef - ref to the dialog container
+ * @param {boolean} active - whether the trap should be engaged
+ */
+export function useFocusTrap(containerRef, active) {
+  const previouslyFocused = useRef(null);
+
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    previouslyFocused.current = document.activeElement;
+
+    const getFocusables = () =>
+      Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+        (el) => el.offsetParent !== null || el === document.activeElement,
+      );
+
+    // Move focus into the dialog on open
+    const initial = getFocusables();
+    if (initial.length > 0) {
+      initial[0].focus();
+    } else {
+      container.setAttribute("tabindex", "-1");
+      container.focus();
+    }
+
+    function handleKeyDown(event) {
+      if (event.key !== "Tab") {
+        return;
+      }
+      const items = getFocusables();
+      if (items.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    container.addEventListener("keydown", handleKeyDown);
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+      const trigger = previouslyFocused.current;
+      if (trigger && typeof trigger.focus === "function") {
+        trigger.focus();
+      }
+    };
+  }, [active, containerRef]);
+}

--- a/src/frontend/src/styles.css
+++ b/src/frontend/src/styles.css
@@ -1,4 +1,7 @@
-@import url("https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap");
+/* Fonts (IBM Plex Sans + Space Grotesk) are preloaded via <link> in index.html.
+   Previously this file @imported "Public Sans", which was never referenced by
+   the Tailwind fontFamily config actually in use — a redundant network request
+   that has been removed to keep typography single-sourced. */
 
 @tailwind base;
 @tailwind components;
@@ -168,6 +171,23 @@
   button,
   input {
     font: inherit;
+  }
+
+  /* ── Keyboard focus indicator (WCAG 2.4.7 Focus Visible) ──
+     Provides a consistent accent-colored outline for keyboard
+     navigation. Elements that already declare their own focus style
+     (e.g. inputs with `focus:border-accent` + `outline-none`) keep
+     that style because Tailwind utilities win source-order over base.
+     This rule fills the gap for icon buttons / link-style controls
+     that previously had no visible focus ring. */
+  :focus-visible {
+    outline: 2px solid rgb(var(--workspace-accent-color));
+    outline-offset: 2px;
+  }
+
+  /* Mouse clicks should not show the keyboard focus ring */
+  :focus:not(:focus-visible) {
+    outline: none;
   }
 
   * {

--- a/src/frontend/tailwind.config.js
+++ b/src/frontend/tailwind.config.js
@@ -10,25 +10,17 @@ export default {
   theme: {
     extend: {
       colors: {
-        sky: colors.indigo,
+        // `sky` previously aliased to indigo (confusing); dev showcase now uses
+        // `indigo-*` directly. `brand` teal palette was never referenced — removed.
         indigo: colors.indigo,
         accent: 'rgb(var(--workspace-accent-color) / <alpha-value>)',
-        brand: {
-          50: '#F0FDFA',
-          100: '#CCFBF1',
-          200: '#99F6E4',
-          300: '#5EEAD4',
-          400: '#2DD4BF',
-          500: '#14B8A6',
-          600: '#0D9488',
-          700: '#0F766E', // Primary teal
-          800: '#115E59',
-          900: '#134E4A',
-          950: '#042F2E',
-        },
       },
       fontFamily: {
-        sans: ['Public Sans', 'Inter', 'Segoe UI', 'sans-serif'],
+        // Match the fonts actually loaded in index.html (IBM Plex Sans + Space Grotesk).
+        // Previously declared 'Public Sans' which was never loaded, causing silent
+        // fallback to system fonts instead of the intended typography.
+        sans: ['"IBM Plex Sans"', 'Inter', '"Segoe UI"', 'sans-serif'],
+        display: ['"Space Grotesk"', '"IBM Plex Sans"', 'sans-serif'],
       },
       borderRadius: {
         '2xl': '1rem',      // 16px

--- a/tests/backend/unit/workspace/test_local_media_imports.py
+++ b/tests/backend/unit/workspace/test_local_media_imports.py
@@ -38,6 +38,67 @@ class LocalMediaImportTests(unittest.TestCase):
                     ],
                 )
 
+    def test_import_local_series_from_paths_creates_hardlinks_and_persists_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_dir = Path(temp_dir)
+            source_path = root_dir / "source.mp4"
+            source_path.write_bytes(b"video")
+            workspace = FileSystemVideoWorkspace(root_dir)
+
+            series = workspace.import_local_series_from_paths(
+                title="Hardlink Course",
+                source_paths=[source_path],
+                storage_mode="hardlink",
+            )
+
+            imported_path = root_dir / "videos" / series.id / source_path.name
+            self.assertEqual(source_path.stat().st_ino, imported_path.stat().st_ino)
+            self.assertEqual(2, imported_path.stat().st_nlink)
+            self.assertIn('"storage_mode": "hardlink"', (root_dir / "workspace" / series.id / "series_meta.json").read_text(encoding="utf-8"))
+
+    def test_append_from_paths_inherits_hardlink_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_dir = Path(temp_dir)
+            first_source = root_dir / "first.mp4"
+            second_source = root_dir / "second.mp4"
+            first_source.write_bytes(b"first")
+            second_source.write_bytes(b"second")
+            workspace = FileSystemVideoWorkspace(root_dir)
+            series = workspace.import_local_series_from_paths(
+                title="Hardlink Course",
+                source_paths=[first_source],
+                storage_mode="hardlink",
+            )
+
+            workspace.import_local_series_videos_from_paths(
+                series_id=series.id,
+                source_paths=[second_source],
+            )
+
+            imported_path = root_dir / "videos" / series.id / second_source.name
+            self.assertEqual(second_source.stat().st_ino, imported_path.stat().st_ino)
+
+    def test_legacy_series_defaults_to_copy_for_path_imports(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_dir = Path(temp_dir)
+            source_path = root_dir / "source.mp4"
+            source_path.write_bytes(b"video")
+            workspace = FileSystemVideoWorkspace(root_dir)
+            series = workspace.import_local_series(
+                title="Legacy Course",
+                files=[("first.mp4", io.BytesIO(b"first"))],
+            )
+            meta_path = root_dir / "workspace" / series.id / "series_meta.json"
+            meta_path.write_text('{"title": "Legacy Course"}', encoding="utf-8")
+
+            workspace.import_local_series_videos_from_paths(
+                series_id=series.id,
+                source_paths=[source_path],
+            )
+
+            imported_path = root_dir / "videos" / series.id / source_path.name
+            self.assertNotEqual(source_path.stat().st_ino, imported_path.stat().st_ino)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add copy and hard-link storage modes for local media series
- use the native local file picker and validate the source volume before hard-linking
- include the current workspace UI, accessibility, and visual refinements

## Validation
- PYTHONPATH=src python -m unittest tests.backend.unit.workspace.test_local_media_imports
- npm test -- --run tests/frontend/features/workspace/ui/workspacePageModel.test.jsx
- npm run build

Closes #47