### PR TITLE
fix: recover generation when staging directory is removed

### DIFF
--- a/src/backend/video_summary/generation/usecases/generate_summary.py
+++ b/src/backend/video_summary/generation/usecases/generate_summary.py
@@ -144,22 +144,28 @@ class GenerateVideoSummary:
         """前置取消检查 → 准备 staging 目录 → 跑核心流水线 → 清理 staging。
 
         任何阶段失败/取消都会通过 `finally` 清理 staging 目录，
-        确保既有 `output_dir` 不会被污染。
+        确保既有 `output_dir` 不会被污染。若 staging 目录在流水线中被
+        异常删除，则只重试一次，并复用已完成的阶段缓存。
         """
         _raise_if_cancelled(progress_reporter)
         await asyncio.to_thread(output_dir.mkdir, parents=True, exist_ok=True)
-        staging_dir = output_dir.parent / f".{output_dir.name}.generation-{uuid4().hex}.tmp"
-        await asyncio.to_thread(staging_dir.mkdir, parents=True, exist_ok=False)
-        try:
-            return await self._run_to_staging(
-                video_path=video_path,
-                output_dir=output_dir,
-                staging_dir=staging_dir,
-                progress_reporter=progress_reporter,
-                cancellation=cancellation,
-            )
-        finally:
-            await asyncio.to_thread(_remove_tree_if_exists, staging_dir)
+        for attempt in range(2):
+            staging_dir = output_dir.parent / f".{output_dir.name}.generation-{uuid4().hex}.tmp"
+            await asyncio.to_thread(staging_dir.mkdir, parents=True, exist_ok=False)
+            try:
+                return await self._run_to_staging(
+                    video_path=video_path,
+                    output_dir=output_dir,
+                    staging_dir=staging_dir,
+                    progress_reporter=progress_reporter,
+                    cancellation=cancellation,
+                )
+            except FileNotFoundError:
+                if attempt == 0 and not staging_dir.exists():
+                    continue
+                raise
+            finally:
+                await asyncio.to_thread(_remove_tree_if_exists, staging_dir)
 
     async def _run_to_staging(
         self,

--- a/tests/backend/unit/generation/test_generate_summary_cancellation.py
+++ b/tests/backend/unit/generation/test_generate_summary_cancellation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -395,6 +396,37 @@ class GenerateVideoSummaryCancellationTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(first_enhancer.calls, 1)
             self.assertEqual(second_enhancer.calls, 0)
             self.assertTrue((output_dir / ".cache" / "transcript-enhance" / "transcript.enhanced.json").exists())
+
+    async def test_external_staging_removal_matches_issue_50_and_retry_recovers(self) -> None:
+        """External staging deletion matches Issue #50 without poisoning a retry."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            video_path = root / "v.mp4"
+            video_path.write_text("video", encoding="utf-8")
+            output_dir = root / "workspace" / "series-1" / "video-1"
+            use_case = GenerateVideoSummary(
+                media_processor=WritingMediaProcessor(),
+                transcriber=FakeTranscriber(),
+                transcript_enhancer=None,
+                summarizer=FakeSummarizer(),
+                artifact_store=FileSystemGenerationArtifactStore(),
+            )
+            original_write_text = Path.write_text
+
+            def remove_staging_before_temp_write(path: Path, *args, **kwargs):
+                if path.name.startswith(".transcript.cleaned.json."):
+                    shutil.rmtree(path.parent)
+                return original_write_text(path, *args, **kwargs)
+
+            with patch.object(Path, "write_text", new=remove_staging_before_temp_write):
+                with self.assertRaisesRegex(FileNotFoundError, r"\.transcript\.cleaned\.json\..+\.tmp"):
+                    await use_case.run(video_path, output_dir)
+
+            document = await use_case.run(video_path, output_dir)
+
+            self.assertEqual(document.summary_data["title"], "Test")
+            self.assertTrue((output_dir / "transcript.cleaned.json").exists())
+            self.assertTrue((output_dir / "summary.json").exists())
 
 
 async def _fake_to_thread(func, *args, **kwargs):

--- a/tests/backend/unit/generation/test_generate_summary_cancellation.py
+++ b/tests/backend/unit/generation/test_generate_summary_cancellation.py
@@ -397,34 +397,39 @@ class GenerateVideoSummaryCancellationTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(second_enhancer.calls, 0)
             self.assertTrue((output_dir / ".cache" / "transcript-enhance" / "transcript.enhanced.json").exists())
 
-    async def test_external_staging_removal_matches_issue_50_and_retry_recovers(self) -> None:
-        """External staging deletion matches Issue #50 without poisoning a retry."""
+    async def test_external_staging_removal_retries_generation_once(self) -> None:
+        """A lost staging directory restarts from durable stage cache once."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
             video_path = root / "v.mp4"
             video_path.write_text("video", encoding="utf-8")
             output_dir = root / "workspace" / "series-1" / "video-1"
+            media_processor = WritingMediaProcessor()
+            transcriber = FakeTranscriber()
             use_case = GenerateVideoSummary(
-                media_processor=WritingMediaProcessor(),
-                transcriber=FakeTranscriber(),
+                media_processor=media_processor,
+                transcriber=transcriber,
                 transcript_enhancer=None,
                 summarizer=FakeSummarizer(),
                 artifact_store=FileSystemGenerationArtifactStore(),
             )
             original_write_text = Path.write_text
+            removed_staging = False
 
             def remove_staging_before_temp_write(path: Path, *args, **kwargs):
-                if path.name.startswith(".transcript.cleaned.json."):
+                nonlocal removed_staging
+                if not removed_staging and path.name.startswith(".transcript.cleaned.json."):
+                    removed_staging = True
                     shutil.rmtree(path.parent)
                 return original_write_text(path, *args, **kwargs)
 
             with patch.object(Path, "write_text", new=remove_staging_before_temp_write):
-                with self.assertRaisesRegex(FileNotFoundError, r"\.transcript\.cleaned\.json\..+\.tmp"):
-                    await use_case.run(video_path, output_dir)
+                document = await use_case.run(video_path, output_dir)
 
-            document = await use_case.run(video_path, output_dir)
-
+            self.assertTrue(removed_staging)
             self.assertEqual(document.summary_data["title"], "Test")
+            self.assertEqual(media_processor.extract_calls, 1)
+            self.assertEqual(transcriber.calls, 1)
             self.assertTrue((output_dir / "transcript.cleaned.json").exists())
             self.assertTrue((output_dir / "summary.json").exists())
 


### PR DESCRIPTION
## Summary
- retry a video generation once when its unique staging directory disappears during processing
- reuse completed stage cache during the retry
- cover the Issue #50 temporary transcript write failure path

## Verification
- `PYTHONPATH=src python -m unittest tests.backend.unit.generation.test_generate_summary_cancellation -v`