### PR TITLE
fix: prioritize packaged CUDA DLLs for FastEmbed

### DIFF
--- a/src/backend/video_summary/infrastructure/rag/agent_memory/fastembed_adapter.py
+++ b/src/backend/video_summary/infrastructure/rag/agent_memory/fastembed_adapter.py
@@ -194,9 +194,14 @@ def _add_python_environment_cuda_dll_directories() -> None:
 
 
 def _prepare_cuda_runtime() -> None:
-    """GPU 初始化前的 Windows CUDA 运行时准备：注册 DLL 搜索路径并预加载关键 DLL。"""
+    """GPU 初始化前的 Windows CUDA 运行时准备。
+
+    整合包自带的 CUDA DLL 必须排在系统 CUDA 目录之前，避免 Windows
+    将不同版本的 cudart / cuDNN 混合加载。
+    """
     if sys.platform != "win32":
         return
+    _prepend_python_environment_cuda_dll_dirs_to_path()
     _add_python_environment_cuda_dll_directories()
     _preload_python_environment_cuda_dlls()
 
@@ -211,6 +216,28 @@ def _preload_python_environment_cuda_dlls() -> None:
         if dll_path is None:
             continue
         _PRELOADED_CUDA_DLLS.append(ctypes.CDLL(str(dll_path)))
+
+
+def _prepend_python_environment_cuda_dll_dirs_to_path() -> None:
+    """将整合包 CUDA DLL 目录前置到进程 PATH，且重复调用不会累积条目。"""
+    dll_dirs = _iter_python_environment_cuda_dll_dirs()
+    if not dll_dirs:
+        return
+
+    package_entries = [str(path) for path in dll_dirs]
+    package_entry_keys = {_normalize_path_entry(entry) for entry in package_entries}
+    existing_entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
+    remaining_entries = [
+        entry
+        for entry in existing_entries
+        if _normalize_path_entry(entry) not in package_entry_keys
+    ]
+    os.environ["PATH"] = os.pathsep.join([*package_entries, *remaining_entries])
+
+
+def _normalize_path_entry(entry: str) -> str:
+    """生成用于 PATH 去重的跨平台规范化键。"""
+    return os.path.normcase(os.path.normpath(entry))
 
 
 def _find_cuda_dll(dll_dirs: list[Path], dll_name: str) -> Path | None:

--- a/tests/backend/unit/agent_memory/test_fastembed_adapter.py
+++ b/tests/backend/unit/agent_memory/test_fastembed_adapter.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
+from backend.video_summary.infrastructure.rag.agent_memory import fastembed_adapter
 from backend.video_summary.infrastructure.rag.agent_memory.fastembed_adapter import FastEmbedEmbedding
 
 
@@ -51,6 +55,28 @@ class FastEmbedEmbeddingTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(RuntimeError, "CUDAExecutionProvider 未激活"):
                 FastEmbedEmbedding(model_name="model", device="gpu", embed_batch_size=4)
+
+    def test_cuda_dll_dirs_precede_system_cuda_path_idempotently(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            package_dirs = [root / "runtime" / "nvidia" / name / "bin" for name in ("cublas", "cudnn")]
+            for path in package_dirs:
+                path.mkdir(parents=True)
+            system_cuda_dir = root / "system-cuda" / "bin"
+            system_cuda_dir.mkdir(parents=True)
+
+            with (
+                patch.object(fastembed_adapter, "_iter_python_environment_cuda_dll_dirs", return_value=package_dirs),
+                patch.dict(os.environ, {"PATH": os.pathsep.join([str(system_cuda_dir), str(package_dirs[0])])}, clear=True),
+            ):
+                fastembed_adapter._prepend_python_environment_cuda_dll_dirs_to_path()
+                first_path = os.environ["PATH"]
+                fastembed_adapter._prepend_python_environment_cuda_dll_dirs_to_path()
+                self.assertEqual(os.environ["PATH"], first_path)
+                self.assertEqual(
+                    first_path.split(os.pathsep),
+                    [str(package_dirs[0]), str(package_dirs[1]), str(system_cuda_dir)],
+                )
 
 
 class _FakeTextEmbedding:


### PR DESCRIPTION
## Summary
- prepend CUDA DLL directories from the packaged Python environment before FastEmbed loads ONNX Runtime
- preserve system CUDA entries after packaged dependencies and avoid duplicate PATH entries
- cover package-over-system DLL priority and repeated initialization

Fixes #49

## Verification
- `PYTHONPATH=src python -m unittest tests.backend.unit.agent_memory.test_fastembed_adapter -v`
- `PYTHONPATH=src python -m unittest tests.backend.unit.packaging.test_diagnose_gpu -v`