### PR TITLE
fix: guide Whisper toward simplified Chinese

### DIFF
--- a/config/settings.toml.example
+++ b/config/settings.toml.example
@@ -17,6 +17,8 @@ model_size = "large-v3-turbo"
 compute_type = "float16"
 # 转写策略。"fast" 更快，"balanced" 平衡速度和质量，"accurate" 更重视准确度。
 transcription_mode = "accurate"
+# 转写首段上下文提示词，用于引导 Whisper 优先使用简体中文。
+initial_prompt = "以下为简体中文普通话转写文本。"
 
 # 前端工作区显示设置。
 [workspace_ui]

--- a/scripts/package/settings.cpu.toml
+++ b/scripts/package/settings.cpu.toml
@@ -8,6 +8,7 @@ device = "cpu"
 model_size = "large-v3-turbo"
 compute_type = "int8"
 transcription_mode = "accurate"
+initial_prompt = "以下为简体中文普通话转写文本。"
 
 [workspace_ui]
 theme = "light"

--- a/scripts/package/settings.gpu.toml
+++ b/scripts/package/settings.gpu.toml
@@ -8,6 +8,7 @@ device = "gpu"
 model_size = "large-v3-turbo"
 compute_type = "float16"
 transcription_mode = "accurate"
+initial_prompt = "以下为简体中文普通话转写文本。"
 
 [workspace_ui]
 theme = "light"

--- a/src/backend/video_summary/infrastructure/asr/faster_whisper_transcriber.py
+++ b/src/backend/video_summary/infrastructure/asr/faster_whisper_transcriber.py
@@ -29,7 +29,7 @@ class FasterWhisperTranscriber:
     通常以"全局单例/单 process 持有"的方式复用。
 
     Attributes:
-        cache_identity: 由类名 + 关键参数（模型、设备、计算精度、转写模式、语言）
+        cache_identity: 由类名 + 关键参数（模型、设备、计算精度、转写模式、语言、提示词）
             拼接而成的字符串，用于上层判断"两个转写器实例是否可复用 cache"。
     """
 
@@ -40,6 +40,7 @@ class FasterWhisperTranscriber:
         compute_type: str,
         transcription_mode: str,
         language: str = "zh",
+        initial_prompt: str = "",
     ) -> None:
         """加载 faster-whisper 模型并预编译解码参数。
 
@@ -51,6 +52,7 @@ class FasterWhisperTranscriber:
             transcription_mode: 转写模式，决定 beam_size 等解码参数
                 （见 `_build_decode_options`）。
             language: 强制指定的语言代码，默认 `zh`。
+            initial_prompt: 转写首段的上下文提示词；用于引导输出为简体中文。
 
         Raises:
             RuntimeError: faster-whisper 未安装，或要求 GPU 但未检测到 NVIDIA runtime。
@@ -68,6 +70,7 @@ class FasterWhisperTranscriber:
                 compute_type,
                 transcription_mode,
                 language,
+                initial_prompt,
             ]
         )
         try:
@@ -76,7 +79,7 @@ class FasterWhisperTranscriber:
             raise RuntimeError("faster-whisper is not installed.") from error
 
         self._language = language
-        self._decode_options = _build_decode_options(transcription_mode)
+        self._decode_options = _build_decode_options(transcription_mode, initial_prompt)
         self._model = WhisperModel(
             model_size,
             device=resolved_device,
@@ -233,7 +236,7 @@ def _discover_nvidia_bin_dirs() -> list[Path]:
     return candidates
 
 
-def _build_decode_options(transcription_mode: str) -> dict[str, object]:
+def _build_decode_options(transcription_mode: str, initial_prompt: str) -> dict[str, object]:
     """根据 `transcription_mode` 构造 faster-whisper 的解码参数。
 
     模式：
@@ -243,27 +246,32 @@ def _build_decode_options(transcription_mode: str) -> dict[str, object]:
 
     Args:
         transcription_mode: 模式名，大小写不敏感；未知值走 fast 路径。
+        initial_prompt: 转写首段的上下文提示词；空字符串时不传给模型。
 
     Returns:
         将被 `WhisperModel.transcribe` 解包为关键字参数的 dict。
     """
     if transcription_mode == "accurate":
-        return {
+        options = {
             "beam_size": 5,
             "best_of": 5,
             "condition_on_previous_text": True,
             "temperature": [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
         }
-    if transcription_mode == "balanced":
-        return {
+    elif transcription_mode == "balanced":
+        options = {
             "beam_size": 3,
             "best_of": 3,
             "condition_on_previous_text": True,
             "temperature": 0.0,
         }
-    return {
-        "beam_size": 1,
-        "best_of": 1,
-        "condition_on_previous_text": False,
-        "temperature": 0.0,
-    }
+    else:
+        options = {
+            "beam_size": 1,
+            "best_of": 1,
+            "condition_on_previous_text": False,
+            "temperature": 0.0,
+        }
+    if initial_prompt:
+        options["initial_prompt"] = initial_prompt
+    return options

--- a/src/backend/video_summary/infrastructure/config/settings.py
+++ b/src/backend/video_summary/infrastructure/config/settings.py
@@ -141,6 +141,7 @@ DEFAULT_WEB_SEARCH_MAX_RESULTS = 5
 DEFAULT_WEB_SEARCH_TIMEOUT_SECONDS = 10
 DEFAULT_CHAOXING_REQUEST_DELAY_SECONDS = 0.2
 DEFAULT_CHAOXING_INIT_COURSE_DELAY_SECONDS = 0.3
+DEFAULT_FASTER_WHISPER_INITIAL_PROMPT = "以下为简体中文普通话转写文本。"
 SUPPORTED_HUGGINGFACE_ENV_KEYS = ("HF_ENDPOINT", "HF_HOME", "HUGGINGFACE_HUB_CACHE")
 
 
@@ -153,6 +154,7 @@ class FasterWhisperSettings:
         model_size: 模型 ID（如 `small` / `large-v3-turbo`）。
         compute_type: 计算精度（如 `int8` / `float16`）。
         transcription_mode: 转写模式，决定 beam_size 等解码参数。
+        initial_prompt: 转写首段的上下文提示词，用于引导模型输出风格。
         models_dir: faster-whisper 模型缓存根目录。
     """
 
@@ -160,6 +162,7 @@ class FasterWhisperSettings:
     model_size: str
     compute_type: str
     transcription_mode: str
+    initial_prompt: str
     models_dir: Path
 
 
@@ -380,6 +383,10 @@ def load_settings(config_path: Path, root_dir: Path) -> AppSettings:
         model_size=faster_payload["model_size"],
         compute_type=faster_payload["compute_type"],
         transcription_mode=_normalize_transcription_mode(faster_payload.get("transcription_mode")),
+        initial_prompt=_normalize_string(
+            faster_payload.get("initial_prompt"),
+            default=DEFAULT_FASTER_WHISPER_INITIAL_PROMPT,
+        ),
         models_dir=root_dir / "data" / "models" / "faster-whisper",
     )
 
@@ -862,6 +869,7 @@ def _render_settings_toml(settings: AppSettings) -> str:
         f'model_size = "{settings.asr.faster_whisper.model_size}"',
         f'compute_type = "{settings.asr.faster_whisper.compute_type}"',
         f'transcription_mode = "{settings.asr.faster_whisper.transcription_mode}"',
+        f"initial_prompt = {_toml_string(settings.asr.faster_whisper.initial_prompt)}",
         "",
         "[workspace_ui]",
         f'theme = "{settings.workspace_ui.theme}"',

--- a/src/backend/video_summary/infrastructure/runtime.py
+++ b/src/backend/video_summary/infrastructure/runtime.py
@@ -136,6 +136,7 @@ def _build_transcriber(settings: AppSettings) -> tuple[Transcriber, AsrRuntimeIn
                 compute_type=settings.asr.faster_whisper.compute_type,
                 transcription_mode=settings.asr.faster_whisper.transcription_mode,
                 language=settings.asr.language,
+                initial_prompt=settings.asr.faster_whisper.initial_prompt,
             ),
             AsrRuntimeInfo(
                 provider=provider,

--- a/src/backend/video_summary/infrastructure/video_summary_runtime.py
+++ b/src/backend/video_summary/infrastructure/video_summary_runtime.py
@@ -150,6 +150,7 @@ def _build_transcriber(settings: AppSettings) -> tuple[Transcriber, AsrRuntimeIn
                 compute_type=settings.asr.faster_whisper.compute_type,
                 transcription_mode=settings.asr.faster_whisper.transcription_mode,
                 language=settings.asr.language,
+                initial_prompt=settings.asr.faster_whisper.initial_prompt,
             ),
             AsrRuntimeInfo(
                 provider=provider,

--- a/tests/backend/unit/generation/test_faster_whisper_transcriber.py
+++ b/tests/backend/unit/generation/test_faster_whisper_transcriber.py
@@ -4,6 +4,7 @@ import sys
 import types
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -45,9 +46,41 @@ class FasterWhisperTranscriberTests(unittest.TestCase):
         ):
             self.assertEqual(_discover_nvidia_bin_dirs(), [])
 
+    def test_transcriber_passes_initial_prompt_to_faster_whisper(self) -> None:
+        fake_module = types.ModuleType("faster_whisper")
+        fake_module.WhisperModel = FakeWhisperModel
+        previous_module = sys.modules.get("faster_whisper")
+        sys.modules["faster_whisper"] = fake_module
+        try:
+            transcriber = FasterWhisperTranscriber(
+                "model-dir",
+                device="cpu",
+                compute_type="int8",
+                transcription_mode="fast",
+                initial_prompt="以下为简体中文普通话转写文本。",
+            )
+            with patch.object(
+                transcriber._model,
+                "transcribe",
+                return_value=(iter([]), SimpleNamespace(duration=0, language="zh")),
+            ) as transcribe:
+                transcriber.transcribe(Path("audio.wav"), Path("transcript"))
+        finally:
+            if previous_module is None:
+                sys.modules.pop("faster_whisper", None)
+            else:
+                sys.modules["faster_whisper"] = previous_module
+
+        self.assertEqual(transcribe.call_args.kwargs["initial_prompt"], "以下为简体中文普通话转写文本。")
+        self.assertIn("以下为简体中文普通话转写文本。", transcriber.cache_identity)
+
 
 class FakeWhisperModel:
     def __init__(self, model_size: str, *, device: str, compute_type: str) -> None:
         self.model_size = model_size
         self.device = device
         self.compute_type = compute_type
+
+    def transcribe(self, audio_path: str, **kwargs):
+        del audio_path, kwargs
+        raise AssertionError("transcribe must be patched in this test")

--- a/tests/backend/unit/settings/test_workspace_settings_service.py
+++ b/tests/backend/unit/settings/test_workspace_settings_service.py
@@ -326,6 +326,21 @@ class WorkspaceSettingsServiceTests(unittest.TestCase):
             self.assertEqual(settings.web_search.max_results, 5)
             self.assertEqual(settings.web_search.timeout_seconds, 10)
 
+    def test_load_settings_uses_simplified_chinese_prompt_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_dir = Path(temp_dir)
+            (root_dir / "config").mkdir(parents=True, exist_ok=True)
+            (root_dir / ".env").write_text("", encoding="utf-8")
+            config_path = root_dir / "config" / "settings.toml"
+            config_path.write_text(_sample_settings_toml(), encoding="utf-8")
+
+            settings = load_settings(config_path, root_dir)
+
+            self.assertEqual(
+                settings.asr.faster_whisper.initial_prompt,
+                "以下为简体中文普通话转写文本。",
+            )
+
     def test_load_settings_creates_local_settings_from_example_when_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root_dir = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Add a configurable simplified-Chinese initial prompt for faster-whisper.
- Pass the prompt through both runtime builders and include it in the transcript cache identity.
- Update source and package configuration defaults with regression tests.

## Tests
- $env:PYTHONPATH = 'src'; python -m unittest tests.backend.unit.generation.test_faster_whisper_transcriber tests.backend.unit.settings.test_workspace_settings_service

Closes #59