### PR TITLE
feat: prefer subtitles for video transcripts

### DIFF
--- a/docs/plans/issue-57-subtitle-first-transcript.md
+++ b/docs/plans/issue-57-subtitle-first-transcript.md
@@ -1,0 +1,260 @@
+# Issue #57：视频内置字幕优先转写实施计划
+
+## 目标
+
+当视频已经提供可用的简体中文字幕时，直接把字幕转换为项目既有的
+`Transcript`，跳过音频提取和 ASR；没有合格中文字幕时，保持现有
+`ffmpeg -> faster-whisper/阿里云百炼 -> Transcript` 流程不变。
+
+本次只处理两类**视频来源**：
+
+1. Bilibili 链接的视频字幕。
+2. 本地视频容器内的文本字幕流。
+
+最终的总结、知识库、转写阅读和导出继续读取既有
+`transcript.cleaned.json`，不为字幕新增并行的下游数据格式。
+
+## 非目标
+
+- 不新增独立 `.srt` 文件上传，也不增加新的 `source_type`。
+- 不把英文、日文或其他语言轨道送入默认中文总结流程。
+- 不对 PGS、VobSub、DVD subtitle 等图片字幕做 OCR。
+- 不下载 Bilibili 视频后再扫描容器字幕；Bilibili 字幕应直接来自其字幕
+  接口。
+- 不移除或弱化 ASR；字幕只是一个优先的转写来源。
+- 不把弹幕 XML 当作字幕。
+
+## 已验证事实
+
+### Bilibili / yt-dlp
+
+项目运行环境已升级到 `yt-dlp 2026.07.04`。Bilibili 提取器会请求
+`x/player/wbi/v2` 的字幕信息，并把 `subtitle_url` 返回的 JSON 转成内存
+中的 SRT 文本。
+
+通过项目 `.env` 中的登录 Cookie 验证：
+
+| BV 号 | 可用轨道 | 验证结果 |
+| --- | --- | --- |
+| `BV12N4y1M7rh`（yt-dlp 官方测试样例） | `zh-Hans` | 成功取得非空 SRT |
+| `BV1vJ3P6KEkh` | `ai-zh`、其他语言 | `ai-zh` 成功取得非空 SRT |
+| `BV1NoTk6SERz` | `ai-en`、`ai-ja` | 无可接受中文轨道，应回退 ASR |
+
+这里有一个必须保留的调用条件：对于 Python API，只有在
+`YoutubeDL(..., listsubtitles=True)` 时，处理后的 `info["subtitles"]` 会保留
+字幕条目及其 `data`（SRT 文本）。只设置 `skip_download=True` 并检查
+`info["subtitles"]` 会得到错误的空结果。
+
+当前 `src/backend/bilibili/ytdlp_bilibili.py` 的 `_extract_info()` 使用
+`extract_flat="in_playlist"` 解析目录。该模式必须保持给解析系列/分 P 的
+轻量用途，不能改成所有请求都抓取视频详情；字幕应有独立的按视频、按分 P
+详情提取器。
+
+### 本地视频
+
+已用 `ffprobe` 识别 `mov_text` 流，并用：
+
+```text
+ffmpeg -i input.mp4 -map 0:s:0 output.srt
+```
+
+成功导出了可解析 SRT。文本字幕编码以 `subrip`、`webvtt`、`ass`、`ssa`、
+`mov_text` 等为候选；`hdmv_pgs_subtitle`、`dvd_subtitle` 等图片字幕不进入
+字幕转写路径，直接回退 ASR。
+
+## 选择规则
+
+默认只接受简体中文轨道，固定优先级如下：
+
+1. Bilibili 原生 `zh-Hans`。
+2. Bilibili AI 字幕 `ai-zh`。
+3. 本地容器中标记为简体中文的文本字幕流。
+4. 本地容器中标记为中文的文本字幕流；仅在没有更明确的简体标记时使用。
+5. 没有候选或候选无法导出/解析时，回退 ASR。
+
+以下情况一律不选：
+
+- `danmaku`；
+- `ai-en`、`ai-ja` 等非中文轨道；
+- 本地流的语言标签为已知非中文；
+- 图片字幕流；
+- 空 SRT、无有效 cue、时间戳非法或无法解码的字幕内容。
+
+语言匹配应由一个集中定义的规范化函数完成，处理 Bilibili 的 `zh-Hans` /
+`ai-zh` 及 ffprobe 的 BCP 47 / ISO 639 标记；不可在调用点散落字符串判断。
+
+## 目标数据流
+
+```mermaid
+flowchart TD
+    A[视频生成请求] --> B{来源}
+    B -->|Bilibili| C[按 BV 和分 P 拉取字幕详情]
+    B -->|本地视频| D[ffprobe 枚举字幕流]
+    C --> E{存在 zh-Hans 或 ai-zh?}
+    D --> F{存在文本中文流?}
+    E -->|是| G[字幕 SRT 转 Transcript]
+    F -->|是| H[ffmpeg 导出 SRT 转 Transcript]
+    E -->|否| I[现有音频 ASR]
+    F -->|否| I
+    G --> J[可选转写增强]
+    H --> J
+    I --> J
+    J --> K[transcript.cleaned.json]
+    K --> L[总结、知识库、阅读与导出]
+```
+
+字幕来源成功时，不调用 `probe_duration`、`extract_audio` 或
+`Transcriber.transcribe`。视频时长从最后一个有效 cue 的结束时间得到；若
+需要准确媒体时长而没有可用 cue，视为字幕解析失败并走 ASR，而不是混合两条
+链路。
+
+## 架构设计
+
+### 1. 建立字幕转写来源端口
+
+在 generation 层定义一个窄端口，例如：
+
+```python
+class TranscriptSource(Protocol):
+    def load(self, video: VideoAsset) -> Transcript | None: ...
+```
+
+返回 `None` 表示“当前来源没有合格字幕”，不是错误；网络错误、媒体命令失败
+和格式错误应带上下文抛出，由调用方记录后回退 ASR。不要把这些错误伪装成空
+字幕，以免掩盖真实故障。
+
+可提供两个实现：
+
+- `BilibiliSubtitleTranscriptSource`：输入 BVID、分 P 与 Cookie 配置；返回
+  原生 `zh-Hans` 或 `ai-zh` 的 SRT 转写。
+- `EmbeddedSubtitleTranscriptSource`：输入本地视频路径；用 `ffprobe` 发现
+  流并用 `ffmpeg` 导出选中的文本流。
+
+SRT 到 domain `Transcript` 的解析器应为独立的纯函数/适配器，供两个来源共用。
+它负责时间戳、cue 文本、空白行和排序校验；不要在 Bilibili 或 ffmpeg 适配器
+中各自实现一份 SRT 解析。
+
+优先使用成熟库 `srt` 完成 SRT 解析。它是解析依赖，不代表增加 SRT 上传功能。
+
+### 2. 在生成用例中选择来源
+
+`GenerateVideoSummary` 当前无条件执行：
+
+```text
+probe_duration -> extract_audio -> transcribe
+```
+
+将其重构为“先尝试字幕来源，再运行 ASR 回退”的单一分支：
+
+```text
+load subtitle transcript
+    -> 成功：使用字幕的 Transcript 和 cue 结束时间创建 VideoAsset
+    -> 未命中：执行现有 probe/extract_audio/transcribe
+```
+
+转写增强、`save_cleaned_transcript`、总结、原子提交和取消语义保持共有，避免
+复制后半段流水线。
+
+为了避免对非 Bilibili 本地视频调用网络来源，来源选择必须基于库中已有的
+`source_path`、`bilibili_bvid`、`bilibili_page` 等事实，而不是 URL 文本猜测。
+
+### 3. Bilibili 详情提取
+
+在 `src/backend/bilibili/ytdlp_bilibili.py` 增加专用、可注入的字幕提取器：
+
+- 构造对应分 P 的视频 URL。
+- 使用 `skip_download=True`、`noplaylist=True`、`extract_flat=False`、
+  `listsubtitles=True`。
+- 复用现有 `_load_bilibili_headers`、Cookie 文件和代理解析逻辑。
+- 为 `yt-dlp` 注入静默 logger，避免 `listsubtitles` 输出语言表污染后端 stdout。
+- 从 `info["subtitles"]` 读取轨道；过滤 `danmaku`；按选择规则取一个轨道的
+  `data`。
+- `data` 必须是非空字符串；`url` 不能作为最终依赖，因为当前提取器已将其
+  转为内存 SRT。
+
+字幕查询只在用户触发某个视频生成时执行。系列导入与列表浏览继续复用 flat
+解析，避免合集导入时对每一 P 额外请求详情。
+
+### 4. 本地嵌入字幕提取
+
+扩展 `FfmpegMediaProcessor` 或引入同级的专用字幕工具：
+
+1. `ffprobe -show_streams -of json` 获取字幕流索引、codec、language、title。
+2. 过滤文本编码与语言标签，按选择规则确定唯一流。
+3. 使用绝对流索引 `-map 0:<stream-index>` 导出为临时 `.srt`。
+4. 解析临时文件为 `Transcript`，文件位于现有 staging 目录并在结束时清理。
+
+没有中文 language tag 的流不应盲目采用；这会把外语字幕混入中文总结。媒体
+元数据无法证明中文时保守回退 ASR。
+
+### 5. 缓存与制品
+
+`GenerationStageCache` 当前以 `"whisper"` 和转写器 identity 缓存转写。字幕
+应使用独立 stage key，例如 `"subtitle"`，身份至少包含：
+
+- 来源种类（`bilibili` / `embedded`）；
+- 选择器版本与语言优先级版本；
+- Bilibili：BVID、分 P、选中语言、SRT 内容摘要；
+- 本地：媒体文件指纹、字幕流索引、codec、language、字幕字节摘要。
+
+缓存命中直接复用 `Transcript`。任何未命中或字幕不可用都不应复用旧字幕结果；
+这时进入现有 Whisper stage。最终仍只保存既有 `transcript.cleaned.json`，无需
+新增用户可见的字幕制品。
+
+## 进度与错误语义
+
+新增或调整的进度阶段：
+
+| 阶段 | 成功时显示 | 失败/未命中时显示 |
+| --- | --- | --- |
+| `probe_subtitles` | 正在检查中文字幕 | 未找到可用中文字幕，改用语音识别 |
+| `extract_subtitles` | 正在读取中文字幕 | 字幕读取失败，改用语音识别 |
+| 既有 `probe` / `extract_audio` / `transcribe` | 仅 ASR 回退时出现 | 保持现有失败语义 |
+
+“无可接受语言轨道”是正常未命中；Bilibili API 错误、Cookie 失效、yt-dlp 返回
+无效结构、ffprobe/ffmpeg 执行失败及 SRT 格式错误必须在日志/进度详情中保留原因。
+在明确记录后才允许 ASR 回退，不能静默吞掉错误。
+
+## 实施顺序
+
+1. 为 SRT 到 `Transcript` 编写纯解析器和单元测试；加入 `srt` 依赖。
+2. 实现 Bilibili 字幕提取器及其轨道选择器，使用官方 BV 与用户样例的录制
+   fixture 覆盖，不在单元测试中依赖实时网络。
+3. 实现 ffprobe 流发现和 ffmpeg 导出，覆盖 `mov_text`、无语言标签、非中文、
+   PGS 和导出失败。
+4. 将两个来源接入 `GenerateVideoSummary`，保持 ASR 后半段代码只有一份。
+5. 为 stage cache 增加字幕 stage 与 manifest identity。
+6. 将新进度事件映射到 SSE/API/前端现有显示组件；不新增导入 UI。
+7. 使用真实 Bilibili 样例做手工 smoke test，并完成完整自动回归。
+
+## 测试矩阵
+
+| 场景 | 输入 | 预期 |
+| --- | --- | --- |
+| Bilibili 原生简中 | `zh-Hans` SRT | 跳过 ASR，写出标准转写与总结 |
+| Bilibili AI 简中 | `ai-zh` SRT | 跳过 ASR，使用 `ai-zh` |
+| Bilibili 同时有原生简中与 AI 简中 | 两种轨道 | 固定选择 `zh-Hans` |
+| Bilibili 仅英文/日文 | `ai-en`、`ai-ja` | 不使用字幕，运行 ASR |
+| Bilibili 无轨道 | 仅 `danmaku` 或空 | 运行 ASR |
+| Bilibili Cookie/API 失败 | 401/412/异常响应 | 记录原因并回退 ASR |
+| 本地 `mov_text` 简中 | 标记为中文的文本流 | 导出、解析，跳过 ASR |
+| 本地多语言字幕 | 中文和英文文本流 | 固定选择简中/中文流 |
+| 本地仅外语文本字幕 | 英文/日文流 | 运行 ASR |
+| 本地 PGS/VobSub | 图片字幕流 | 运行 ASR |
+| 字幕损坏或无 cue | 非法/空 SRT | 记录原因并运行 ASR |
+| 缓存命中 | 相同视频、轨道和规则版本 | 不重复请求/导出/ASR |
+| 缓存失效 | 轨道、媒体或规则版本变化 | 重新取字幕，再决定是否回退 |
+| 取消 | 字幕提取、ASR、总结任一阶段 | 清理 staging，不污染已提交制品 |
+
+## 验收标准
+
+1. `BV1vJ3P6KEkh` 生成时选择 `ai-zh`，且日志/进度证明没有执行音频提取和
+   ASR。
+2. `BV1NoTk6SERz` 不接受其 `ai-en`、`ai-ja`，完整走现有 ASR。
+3. 官方 `BV12N4y1M7rh` 可读到 `zh-Hans` SRT，作为 Bilibili 提取器的手工
+   兼容性样例。
+4. 带 `mov_text` 中文流的本地 MP4 能直接生成总结；带 PGS 或无中文流的本地
+   视频会回退 ASR。
+5. 输出目录结构和 `transcript.cleaned.json` 格式与纯 ASR 生成保持兼容。
+6. 不新增 SRT 文件导入入口、文件类型、前端表单或 `source_type`。
+7. 后端单元测试、既有生成回归与前端进度相关测试全部通过。

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ llama-index-embeddings-openai>=0.3,<1
 fastembed-gpu>=0.7,<1
 onnxruntime-gpu>=1.20,<1.27
 yt-dlp>=2024.1,<2027
+srt>=3.5,<4
 chaoxing-downloader==0.1.3

--- a/scripts/package/environment.cpu.yml
+++ b/scripts/package/environment.cpu.yml
@@ -26,4 +26,5 @@ dependencies:
     - fastembed>=0.7,<1
     - onnxruntime>=1.20,<2
     - yt-dlp>=2024.1,<2027
+    - srt>=3.5,<4
     - chaoxing-downloader==0.1.3

--- a/scripts/package/environment.gpu.yml
+++ b/scripts/package/environment.gpu.yml
@@ -32,4 +32,5 @@ dependencies:
     - nvidia-cufft-cu12
     - nvidia-curand-cu12
     - yt-dlp>=2024.1,<2027
+    - srt>=3.5,<4
     - chaoxing-downloader==0.1.3

--- a/src/backend/bilibili/ytdlp_bilibili.py
+++ b/src/backend/bilibili/ytdlp_bilibili.py
@@ -13,21 +13,26 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 import time
 from pathlib import Path
 from typing import Callable, Mapping, Protocol
 
 import httpx
 
+from backend.shared.bilibili_ytdlp import (
+    BILIBILI_COOKIE_ENV,
+    BILIBILI_USER_AGENT,
+    build_yt_dlp_add_header_flags,
+    build_yt_dlp_proxy_flags,
+    load_bilibili_headers,
+    parse_cookie_pairs,
+    resolve_yt_dlp_proxy,
+    write_bilibili_cookies_file,
+)
 from backend.shared.filesystem import atomic_write_text
 from backend.video_summary.library.linked_models import LinkedSeries, LinkedVideo
 from backend.video_summary.library.models import BilibiliUrlInfoDTO
 
-_BILIBILI_USER_AGENT = "Mozilla/5.0"
-_BILIBILI_COOKIE_ENV = "BILIBILI_COOKIE"
-_BILIBILI_SESSDATA_ENV = "BILIBILI_SESSDATA"
-_BILIBILI_YTDLP_PROXY_ENV = "BILIBILI_YTDLP_PROXY"
 BILIBILI_COOKIE_REQUIRED_MESSAGE = "风控拦截，请配置cookie"
 _BILIBILI_LOGIN_URL = "https://passport.bilibili.com/login"
 _BILIBILI_DEFAULT_BROWSER_PORT = 9223
@@ -200,8 +205,8 @@ class BilibiliDownloader:
         if page > 1:
             url = f"{url}?p={page}"
         output_template = str(dest_dir / f"{stem}.%(ext)s")
-        headers = _load_bilibili_headers(bvid)
-        cookie_file = _write_bilibili_cookies_file(headers.pop("Cookie", ""))
+        headers = load_bilibili_headers(bvid)
+        cookie_file = write_bilibili_cookies_file(headers.pop("Cookie", ""))
         failures: list[str] = []
         try:
             for index, (format_label, format_selector) in enumerate(_BILIBILI_DOWNLOAD_FORMATS):
@@ -223,8 +228,8 @@ class BilibiliDownloader:
                     "--output",
                     output_template,
                     "--newline",
-                    *_build_yt_dlp_proxy_flags(),
-                    *_build_yt_dlp_add_header_flags(headers),
+                    *build_yt_dlp_proxy_flags(),
+                    *build_yt_dlp_add_header_flags(headers),
                     *(["--cookies", str(cookie_file)] if cookie_file is not None else []),
                     url,
                 ]
@@ -348,8 +353,8 @@ class DrissionBilibiliCookieInitializer:
             while time.monotonic() <= deadline:
                 cookie_header = _format_bilibili_cookie_header(_page_cookies(page))
                 if _has_bilibili_login_cookie(cookie_header):
-                    _write_dotenv_value(self._root_dir / ".env", _BILIBILI_COOKIE_ENV, cookie_header)
-                    os.environ[_BILIBILI_COOKIE_ENV] = cookie_header
+                    _write_dotenv_value(self._root_dir / ".env", BILIBILI_COOKIE_ENV, cookie_header)
+                    os.environ[BILIBILI_COOKIE_ENV] = cookie_header
                     return True
                 time.sleep(self._poll_interval_seconds)
             raise BilibiliCookieInitError("Bilibili 登录超时，未获取到 Cookie。")
@@ -386,42 +391,6 @@ def _download_cancel_requested(reporter: ProgressReporter) -> bool:
     return False
 
 
-def _load_bilibili_headers(bvid: str) -> dict[str, str]:
-    cookie = os.environ.get(_BILIBILI_COOKIE_ENV, "").strip()
-    if not cookie:
-        sessdata = os.environ.get(_BILIBILI_SESSDATA_ENV, "").strip()
-        cookie = f"SESSDATA={sessdata}" if sessdata else ""
-    headers = {
-        "User-Agent": _BILIBILI_USER_AGENT,
-        "Referer": f"https://www.bilibili.com/video/{bvid}/",
-    }
-    if cookie:
-        headers["Cookie"] = cookie
-    return headers
-
-
-def _build_yt_dlp_add_header_flags(headers: dict[str, str]) -> list[str]:
-    flags: list[str] = []
-    for key, value in headers.items():
-        if not value:
-            continue
-        flags.extend(["--add-header", f"{key}:{value}"])
-    return flags
-
-
-def _build_yt_dlp_proxy_flags() -> list[str]:
-    proxy = _resolve_yt_dlp_proxy()
-    return [] if proxy is None else ["--proxy", proxy]
-
-
-def _resolve_yt_dlp_proxy() -> str | None:
-    raw_proxy = os.environ.get(_BILIBILI_YTDLP_PROXY_ENV)
-    if raw_proxy is None or not raw_proxy.strip():
-        return None
-    proxy = raw_proxy.strip()
-    return "" if proxy.lower() in {"direct", "none", "off"} else proxy
-
-
 def _find_download_outputs(dest_dir: Path, stem: str) -> list[Path]:
     return [
         path
@@ -441,33 +410,6 @@ def _format_yt_dlp_failure(returncode: int | None, recent_output: deque[str]) ->
     if not recent_output:
         return message
     return f"{message}；最近输出：\n" + "\n".join(recent_output)
-
-
-def _write_bilibili_cookies_file(cookie: str) -> Path | None:
-    if not cookie.strip():
-        return None
-    cookie_pairs = _parse_cookie_pairs(cookie)
-    if not cookie_pairs:
-        return None
-    handle = tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, suffix=".cookies.txt")
-    with handle:
-        handle.write("# Netscape HTTP Cookie File\n")
-        for name, value in cookie_pairs:
-            handle.write(f".bilibili.com\tTRUE\t/\tTRUE\t0\t{name}\t{value}\n")
-    return Path(handle.name)
-
-
-def _parse_cookie_pairs(cookie: str) -> list[tuple[str, str]]:
-    pairs: list[tuple[str, str]] = []
-    for part in cookie.split(";"):
-        if "=" not in part:
-            continue
-        name, value = part.split("=", 1)
-        normalized_name = name.strip()
-        normalized_value = value.strip()
-        if normalized_name:
-            pairs.append((normalized_name, normalized_value))
-    return pairs
 
 
 def _create_drission_page(user_data_dir: str, browser_port: int) -> object:
@@ -558,7 +500,7 @@ def _format_bilibili_cookie_header(cookies: list[Mapping[str, object]]) -> str:
 
 
 def _has_bilibili_login_cookie(cookie_header: str) -> bool:
-    names = {name for name, _ in _parse_cookie_pairs(cookie_header)}
+    names = {name for name, _ in parse_cookie_pairs(cookie_header)}
     return "SESSDATA" in names
 
 
@@ -713,11 +655,11 @@ def _extract_info(url: str) -> dict[str, object]:
     from yt_dlp import YoutubeDL
 
     bvid = _extract_bvid_from_text(url)
-    headers = _load_bilibili_headers(bvid) if bvid else {
-        "User-Agent": _BILIBILI_USER_AGENT,
+    headers = load_bilibili_headers(bvid) if bvid else {
+        "User-Agent": BILIBILI_USER_AGENT,
         "Referer": "https://www.bilibili.com/",
     }
-    cookie_file = _write_bilibili_cookies_file(headers.pop("Cookie", ""))
+    cookie_file = write_bilibili_cookies_file(headers.pop("Cookie", ""))
     options = {
         "quiet": True,
         "no_warnings": True,
@@ -725,7 +667,7 @@ def _extract_info(url: str) -> dict[str, object]:
         "skip_download": True,
         "http_headers": headers,
     }
-    proxy = _resolve_yt_dlp_proxy()
+    proxy = resolve_yt_dlp_proxy()
     if proxy is not None:
         options["proxy"] = proxy
     if cookie_file is not None:

--- a/src/backend/shared/bilibili_ytdlp.py
+++ b/src/backend/shared/bilibili_ytdlp.py
@@ -1,0 +1,81 @@
+"""Bilibili yt-dlp 访问所需的共享认证与代理工具。"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+BILIBILI_USER_AGENT = "Mozilla/5.0"
+BILIBILI_COOKIE_ENV = "BILIBILI_COOKIE"
+BILIBILI_SESSDATA_ENV = "BILIBILI_SESSDATA"
+BILIBILI_YTDLP_PROXY_ENV = "BILIBILI_YTDLP_PROXY"
+
+
+def load_bilibili_headers(bvid: str) -> dict[str, str]:
+    """构造访问 Bilibili 视频页/API 时使用的基础请求头。"""
+    cookie = os.environ.get(BILIBILI_COOKIE_ENV, "").strip()
+    if not cookie:
+        sessdata = os.environ.get(BILIBILI_SESSDATA_ENV, "").strip()
+        cookie = f"SESSDATA={sessdata}" if sessdata else ""
+    headers = {
+        "User-Agent": BILIBILI_USER_AGENT,
+        "Referer": f"https://www.bilibili.com/video/{bvid}/",
+    }
+    if cookie:
+        headers["Cookie"] = cookie
+    return headers
+
+
+def build_yt_dlp_add_header_flags(headers: dict[str, str]) -> list[str]:
+    """把 yt-dlp Python/CLI 共用的 headers 转成 CLI 参数。"""
+    flags: list[str] = []
+    for key, value in headers.items():
+        if not value:
+            continue
+        flags.extend(["--add-header", f"{key}:{value}"])
+    return flags
+
+
+def build_yt_dlp_proxy_flags() -> list[str]:
+    """把 Bilibili yt-dlp 代理配置转成 CLI 参数。"""
+    proxy = resolve_yt_dlp_proxy()
+    return [] if proxy is None else ["--proxy", proxy]
+
+
+def resolve_yt_dlp_proxy() -> str | None:
+    """读取 Bilibili yt-dlp 代理配置；direct/none/off 表示显式直连。"""
+    raw_proxy = os.environ.get(BILIBILI_YTDLP_PROXY_ENV)
+    if raw_proxy is None or not raw_proxy.strip():
+        return None
+    proxy = raw_proxy.strip()
+    return "" if proxy.lower() in {"direct", "none", "off"} else proxy
+
+
+def write_bilibili_cookies_file(cookie: str) -> Path | None:
+    """把 Cookie header 写成 yt-dlp 支持的 Netscape cookie 文件。"""
+    if not cookie.strip():
+        return None
+    cookie_pairs = parse_cookie_pairs(cookie)
+    if not cookie_pairs:
+        return None
+    handle = tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, suffix=".cookies.txt")
+    with handle:
+        handle.write("# Netscape HTTP Cookie File\n")
+        for name, value in cookie_pairs:
+            handle.write(f".bilibili.com\tTRUE\t/\tTRUE\t0\t{name}\t{value}\n")
+    return Path(handle.name)
+
+
+def parse_cookie_pairs(cookie: str) -> list[tuple[str, str]]:
+    """解析 HTTP Cookie header，保留有名称的键值对。"""
+    pairs: list[tuple[str, str]] = []
+    for part in cookie.split(";"):
+        if "=" not in part:
+            continue
+        name, value = part.split("=", 1)
+        normalized_name = name.strip()
+        normalized_value = value.strip()
+        if normalized_name:
+            pairs.append((normalized_name, normalized_value))
+    return pairs

--- a/src/backend/video_summary/generation/ports.py
+++ b/src/backend/video_summary/generation/ports.py
@@ -43,6 +43,18 @@ class Transcriber(Protocol):
         """把音频文件转写为 `Transcript`；`on_progress` 回调传入 0.0-1.0 的进度比。"""
 
 
+class SubtitleTranscriptSource(Protocol):
+    """从视频关联的字幕来源取得可直接总结的转写。"""
+
+    def load(
+        self,
+        video_path: Path,
+        staging_dir: Path,
+        cancellation: "GenerationCancellationContext | None" = None,
+    ) -> Transcript | None:
+        """返回中文字幕转写；当前视频没有可用字幕时返回 ``None``。"""
+
+
 class Summarizer(Protocol):
     """LLM 总结端口。"""
 

--- a/src/backend/video_summary/generation/usecases/generate_summary.py
+++ b/src/backend/video_summary/generation/usecases/generate_summary.py
@@ -34,6 +34,7 @@ from backend.video_summary.generation.ports import (
     GenerationArtifactStore,
     MediaProcessor,
     ProgressReporter,
+    SubtitleTranscriptSource,
     Summarizer,
     TranscriptEnhancer,
     Transcriber,
@@ -70,6 +71,7 @@ class GenerateVideoSummary:
         transcript_enhancer: TranscriptEnhancer | None,
         summarizer: Summarizer,
         artifact_store: GenerationArtifactStore,
+        subtitle_provider: SubtitleTranscriptSource | None = None,
     ) -> None:
         """注入媒体处理、转写、（可选）转写增强、总结与制品落盘端口。
 
@@ -86,6 +88,7 @@ class GenerateVideoSummary:
         self._transcript_enhancer = transcript_enhancer
         self._summarizer = summarizer
         self._artifact_store = artifact_store
+        self._subtitle_provider = subtitle_provider
 
     async def run(
         self,
@@ -147,7 +150,7 @@ class GenerateVideoSummary:
         确保既有 `output_dir` 不会被污染。若 staging 目录在流水线中被
         异常删除，则只重试一次，并复用已完成的阶段缓存。
         """
-        _raise_if_cancelled(progress_reporter)
+        _raise_if_cancelled(progress_reporter, cancellation)
         await asyncio.to_thread(output_dir.mkdir, parents=True, exist_ok=True)
         for attempt in range(2):
             staging_dir = output_dir.parent / f".{output_dir.name}.generation-{uuid4().hex}.tmp"
@@ -183,60 +186,86 @@ class GenerateVideoSummary:
         2. 优先尝试从 `GenerationStageCache` 复用上一次的中间产物；
         3. 在阻塞调用之前检查取消信号，避免浪费昂贵的计算。
         """
-        audio_path = staging_dir / "audio.wav"
-        transcript_stem = staging_dir / "transcript"
         stage_cache = GenerationStageCache(output_dir / ".cache", video_path)
-        media_identity = _cache_identity(self._media_processor)
-        transcriber_identity = _cache_identity(self._transcriber)
+        subtitle_transcript = None
+        if self._subtitle_provider is not None:
+            if progress_reporter is not None:
+                progress_reporter.update("probe_subtitles", 5.0, "正在检查中文字幕")
+            try:
+                subtitle_transcript = await asyncio.to_thread(
+                    self._subtitle_provider.load,
+                    video_path,
+                    staging_dir,
+                    cancellation,
+                )
+            except InterruptedError as error:
+                raise GenerateCancelledError(str(error) or "生成已取消") from error
+            _raise_if_cancelled(progress_reporter, cancellation)
+
+        if subtitle_transcript is not None:
+            video = VideoAsset(
+                source_path=video_path,
+                title=video_path.stem,
+                duration_seconds=max(segment.end_seconds for segment in subtitle_transcript.segments),
+            )
+            transcript = subtitle_transcript
+            transcript_source_identity = f"subtitle:{_cache_identity(self._subtitle_provider)}"
+            if progress_reporter is not None:
+                progress_reporter.update("extract_subtitles", 20.0, "已读取中文字幕，跳过语音识别")
+        else:
+            audio_path = staging_dir / "audio.wav"
+            transcript_stem = staging_dir / "transcript"
+            media_identity = _cache_identity(self._media_processor)
+            transcriber_identity = _cache_identity(self._transcriber)
+            transcript_source_identity = f"whisper:{transcriber_identity}"
+            if progress_reporter is not None:
+                progress_reporter.update("probe", 5.0, "未找到可用中文字幕，正在分析视频信息")
+            video = VideoAsset(
+                source_path=video_path,
+                title=video_path.stem,
+                duration_seconds=await asyncio.to_thread(self._media_processor.probe_duration, video_path),
+            )
+            _raise_if_cancelled(progress_reporter, cancellation)
+
+            if progress_reporter is not None:
+                progress_reporter.update("extract_audio", 15.0, "正在将视频转换为音频")
+            audio_restored = await asyncio.to_thread(stage_cache.restore_audio, audio_path, identity=media_identity)
+            if not audio_restored:
+                await asyncio.to_thread(self._media_processor.extract_audio, video_path, audio_path, cancellation)
+                _raise_if_cancelled(progress_reporter, cancellation)
+                await asyncio.to_thread(stage_cache.store_audio, audio_path, identity=media_identity)
+            _raise_if_cancelled(progress_reporter, cancellation)
+
+            if progress_reporter is not None:
+                progress_reporter.update("transcribe", 20.0, "正在转写音频")
+            transcript = await asyncio.to_thread(stage_cache.load_transcript, "whisper", identity=transcriber_identity)
+            if transcript is None:
+                transcript = await asyncio.to_thread(
+                    self._transcriber.transcribe,
+                    audio_path,
+                    transcript_stem,
+                    None
+                    if progress_reporter is None
+                    else lambda ratio: _handle_transcribe_progress(progress_reporter, ratio),
+                )
+                _raise_if_cancelled(progress_reporter, cancellation)
+                await asyncio.to_thread(
+                    stage_cache.store_transcript,
+                    "whisper",
+                    transcript,
+                    identity=transcriber_identity,
+                )
+            _raise_if_cancelled(progress_reporter, cancellation)
+
         enhancer_identity = (
-            _cache_identity(self._transcript_enhancer)
+            f"{_cache_identity(self._transcript_enhancer)}|source={transcript_source_identity}"
             if self._transcript_enhancer is not None
             else ""
         )
-
-        if progress_reporter is not None:
-            progress_reporter.update("probe", 5.0, "正在分析视频信息")
-        video = VideoAsset(
-            source_path=video_path,
-            title=video_path.stem,
-            duration_seconds=await asyncio.to_thread(self._media_processor.probe_duration, video_path),
-        )
-        _raise_if_cancelled(progress_reporter)
-
-        if progress_reporter is not None:
-            progress_reporter.update("extract_audio", 15.0, "正在将视频转换为音频")
-        audio_restored = await asyncio.to_thread(stage_cache.restore_audio, audio_path, identity=media_identity)
-        if not audio_restored:
-            await asyncio.to_thread(self._media_processor.extract_audio, video_path, audio_path, cancellation)
-            _raise_if_cancelled(progress_reporter)
-            await asyncio.to_thread(stage_cache.store_audio, audio_path, identity=media_identity)
-        _raise_if_cancelled(progress_reporter)
-
-        if progress_reporter is not None:
-            progress_reporter.update("transcribe", 20.0, "正在转写音频")
-        transcript = await asyncio.to_thread(stage_cache.load_transcript, "whisper", identity=transcriber_identity)
-        if transcript is None:
-            transcript = await asyncio.to_thread(
-                self._transcriber.transcribe,
-                audio_path,
-                transcript_stem,
-                None
-                if progress_reporter is None
-                else lambda ratio: _handle_transcribe_progress(progress_reporter, ratio),
-            )
-            _raise_if_cancelled(progress_reporter)
-            await asyncio.to_thread(
-                stage_cache.store_transcript,
-                "whisper",
-                transcript,
-                identity=transcriber_identity,
-            )
-        _raise_if_cancelled(progress_reporter)
-
         if self._transcript_enhancer is not None:
             if progress_reporter is not None:
                 progress_reporter.update("enhance_transcript", 78.0, "正在用 AI 修正转写文本")
-            _raise_if_cancelled(progress_reporter)
+            _raise_if_cancelled(progress_reporter, cancellation)
             enhanced_transcript = await asyncio.to_thread(
                 stage_cache.load_transcript,
                 "transcript-enhance",
@@ -249,7 +278,7 @@ class GenerateVideoSummary:
                     raise
                 except Exception as error:
                     raise RuntimeError(_build_llm_stage_error("AI 内容增强", error)) from error
-                _raise_if_cancelled(progress_reporter)
+                _raise_if_cancelled(progress_reporter, cancellation)
                 await asyncio.to_thread(
                     stage_cache.store_transcript,
                     "transcript-enhance",
@@ -257,32 +286,32 @@ class GenerateVideoSummary:
                     identity=enhancer_identity,
                 )
             transcript = enhanced_transcript
-            _raise_if_cancelled(progress_reporter)
+            _raise_if_cancelled(progress_reporter, cancellation)
             await self._artifact_store.save_enhanced_transcript(
                 transcript=transcript,
                 output_dir=staging_dir,
             )
-            _raise_if_cancelled(progress_reporter)
+            _raise_if_cancelled(progress_reporter, cancellation)
 
         await self._artifact_store.save_cleaned_transcript(
             video=video,
             transcript=transcript,
             output_dir=staging_dir,
         )
-        _raise_if_cancelled(progress_reporter)
+        _raise_if_cancelled(progress_reporter, cancellation)
 
         if progress_reporter is not None:
             progress_reporter.update("summarize", 88.0, "正在生成 AI 概况")
-        _raise_if_cancelled(progress_reporter)
+        _raise_if_cancelled(progress_reporter, cancellation)
         try:
             summary_document = await self._summarizer.summarize(video, transcript, cancellation)
         except GenerateCancelledError:
             raise
         except Exception as error:
             raise RuntimeError(_build_llm_stage_error("AI 概况生成", error)) from error
-        _raise_if_cancelled(progress_reporter)
+        _raise_if_cancelled(progress_reporter, cancellation)
         await self._artifact_store.save_summary_document(document=summary_document, output_dir=staging_dir)
-        _raise_if_cancelled(progress_reporter)
+        _raise_if_cancelled(progress_reporter, cancellation)
         await asyncio.to_thread(_commit_generation_artifacts, staging_dir, output_dir)
         return summary_document
 
@@ -385,7 +414,10 @@ async def _mirror_progress_cancellation(
         await asyncio.sleep(0.05)
 
 
-def _raise_if_cancelled(progress_reporter: ProgressReporter | None) -> None:
+def _raise_if_cancelled(
+    progress_reporter: ProgressReporter | None,
+    cancellation: GenerationCancellationContext | None = None,
+) -> None:
     """若 reporter 已收到取消信号，则抛 `GenerateCancelledError`。
 
     Args:
@@ -394,6 +426,8 @@ def _raise_if_cancelled(progress_reporter: ProgressReporter | None) -> None:
     Raises:
         GenerateCancelledError: reporter 处于取消态时抛出。
     """
+    if cancellation is not None and cancellation.cancel_requested:
+        raise GenerateCancelledError("生成已取消")
     if progress_reporter is None:
         return
     try:

--- a/src/backend/video_summary/infrastructure/application_builders.py
+++ b/src/backend/video_summary/infrastructure/application_builders.py
@@ -16,6 +16,7 @@ from backend.video_summary.infrastructure.storage.filesystem_generation_artifact
 from backend.video_summary.infrastructure.llm.litellm_mindmap_generator import LiteLLMMindmapGenerator
 from backend.video_summary.infrastructure.llm.litellm_transcript_enhancer import LiteLLMTranscriptEnhancer
 from backend.video_summary.infrastructure.media_tools import FfmpegMediaProcessor
+from backend.video_summary.infrastructure.subtitle_transcripts import SubtitleTranscriptProvider
 from backend.video_summary.infrastructure.video_summary_runtime import (
     build_litellm_completion_gateway,
     build_video_summary_runtime,
@@ -92,6 +93,7 @@ def build_video_summary_application(
         ),
         summarizer=runtime.summarizer,
         artifact_store=artifact_store,
+        subtitle_provider=SubtitleTranscriptProvider(),
     )
     return VideoSummaryApplication(settings=settings, use_case=use_case)
 

--- a/src/backend/video_summary/infrastructure/subtitle_transcripts.py
+++ b/src/backend/video_summary/infrastructure/subtitle_transcripts.py
@@ -1,0 +1,241 @@
+"""从 Bilibili 与本地媒体读取可直接使用的中文字幕转写。"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+import re
+import subprocess
+
+import srt
+
+from backend.shared.bilibili_ytdlp import (
+    load_bilibili_headers,
+    resolve_yt_dlp_proxy,
+    write_bilibili_cookies_file,
+)
+from backend.video_summary.domain.models import Transcript, TranscriptSegment
+from backend.video_summary.generation.cancellation import GenerationCancellationContext, ProcessHandle
+
+LOGGER = logging.getLogger(__name__)
+
+_BVID_PATTERN = re.compile(r"(BV[0-9A-Za-z]{10})", re.IGNORECASE)
+_PAGE_PATTERN = re.compile(r"_p(?P<page>[1-9][0-9]*)$", re.IGNORECASE)
+_TEXT_SUBTITLE_CODECS = frozenset({"ass", "mov_text", "srt", "ssa", "subrip", "webvtt"})
+_LOCAL_CHINESE_LANGUAGE_PRIORITY = ("zh-hans", "zh-cn", "zh", "zho", "chi", "cmn")
+_BILIBILI_CHINESE_LANGUAGE_PRIORITY = ("zh-Hans", "zh-CN", "zh", "ai-zh")
+
+
+class SubtitleTranscriptProvider:
+    """按 Bilibili、内嵌字幕的顺序尝试获得中文字幕转写。"""
+
+    cache_identity = "subtitle-transcript-v1"
+
+    def load(
+        self,
+        video_path: Path,
+        staging_dir: Path,
+        cancellation: GenerationCancellationContext | None = None,
+    ) -> Transcript | None:
+        """返回可用中文字幕；找不到时返回 ``None`` 以让调用方走 ASR。"""
+        bilibili = _load_bilibili_subtitle(video_path, cancellation)
+        if bilibili is not None:
+            return bilibili
+        return _load_embedded_subtitle(video_path, staging_dir / "subtitle.srt", cancellation)
+
+
+class _SilentYtDlpLogger:
+    """阻止 listsubtitles 将轨道表直接写入后端 stdout。"""
+
+    def debug(self, message: str) -> None:
+        LOGGER.debug("yt-dlp: %s", message)
+
+    def warning(self, message: str) -> None:
+        LOGGER.warning("yt-dlp: %s", message)
+
+    def error(self, message: str) -> None:
+        LOGGER.warning("yt-dlp: %s", message)
+
+
+def _load_bilibili_subtitle(
+    video_path: Path,
+    cancellation: GenerationCancellationContext | None = None,
+) -> Transcript | None:
+    bvid_match = _BVID_PATTERN.search(video_path.stem)
+    if bvid_match is None:
+        return None
+    _raise_if_cancelled(cancellation)
+    bvid = bvid_match.group(1)
+    page_match = _PAGE_PATTERN.search(video_path.stem)
+    page = int(page_match.group("page")) if page_match is not None else 1
+    url = f"https://www.bilibili.com/video/{bvid}" + (f"?p={page}" if page > 1 else "")
+    headers = load_bilibili_headers(bvid)
+    cookie_file = write_bilibili_cookies_file(headers.pop("Cookie", ""))
+    options: dict[str, object] = {
+        "quiet": True,
+        "no_warnings": True,
+        "skip_download": True,
+        "noplaylist": True,
+        "extract_flat": False,
+        "listsubtitles": True,
+        "socket_timeout": 20,
+        "http_headers": headers,
+        "logger": _SilentYtDlpLogger(),
+    }
+    proxy = resolve_yt_dlp_proxy()
+    if proxy is not None:
+        options["proxy"] = proxy
+    if cookie_file is not None:
+        options["cookiefile"] = str(cookie_file)
+    try:
+        from yt_dlp import YoutubeDL
+
+        with YoutubeDL(options) as ydl:
+            ydl.to_screen = _discard_ytdlp_screen_output
+            ydl.to_stdout = _discard_ytdlp_screen_output
+            info = ydl.extract_info(url, download=False)
+        _raise_if_cancelled(cancellation)
+        if not isinstance(info, dict):
+            return None
+        subtitles = info.get("subtitles")
+        if not isinstance(subtitles, dict):
+            return None
+        for language in _BILIBILI_CHINESE_LANGUAGE_PRIORITY:
+            entries = subtitles.get(language)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict) or entry.get("ext") != "srt":
+                    continue
+                data = entry.get("data")
+                if isinstance(data, str) and data.strip():
+                    return parse_srt_transcript(data)
+        return None
+    except InterruptedError:
+        raise
+    except Exception:
+        _raise_if_cancelled(cancellation)
+        LOGGER.warning("Bilibili 中文字幕读取失败，回退 ASR：%s", bvid, exc_info=True)
+        return None
+    finally:
+        if cookie_file is not None:
+            cookie_file.unlink(missing_ok=True)
+
+
+def _load_embedded_subtitle(
+    video_path: Path,
+    output_path: Path,
+    cancellation: GenerationCancellationContext | None = None,
+) -> Transcript | None:
+    try:
+        stream_index = _find_chinese_text_subtitle_stream(video_path, cancellation)
+        if stream_index is None:
+            return None
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        _run_subprocess(
+            [
+                "ffmpeg",
+                "-nostdin",
+                "-y",
+                "-i",
+                str(video_path),
+                "-map",
+                f"0:{stream_index}",
+                str(output_path),
+            ],
+            cancellation,
+        )
+        return parse_srt_transcript(output_path.read_text(encoding="utf-8-sig"))
+    except InterruptedError:
+        raise
+    except Exception:
+        _raise_if_cancelled(cancellation)
+        LOGGER.warning("内嵌中文字幕读取失败，回退 ASR：%s", video_path, exc_info=True)
+        return None
+    finally:
+        output_path.unlink(missing_ok=True)
+
+
+def _find_chinese_text_subtitle_stream(
+    video_path: Path,
+    cancellation: GenerationCancellationContext | None = None,
+) -> int | None:
+    result = _run_subprocess(
+        ["ffprobe", "-v", "error", "-show_streams", "-of", "json", str(video_path)],
+        cancellation,
+    )
+    payload = json.loads(result.stdout)
+    streams = payload.get("streams")
+    if not isinstance(streams, list):
+        return None
+    candidates: list[tuple[int, int]] = []
+    for stream in streams:
+        if not isinstance(stream, dict) or stream.get("codec_type") != "subtitle":
+            continue
+        codec = str(stream.get("codec_name", "")).lower()
+        tags = stream.get("tags")
+        language = str(tags.get("language", "")).lower() if isinstance(tags, dict) else ""
+        if codec not in _TEXT_SUBTITLE_CODECS or language not in _LOCAL_CHINESE_LANGUAGE_PRIORITY:
+            continue
+        index = stream.get("index")
+        if not isinstance(index, int):
+            continue
+        candidates.append((_LOCAL_CHINESE_LANGUAGE_PRIORITY.index(language), index))
+    return min(candidates)[1] if candidates else None
+
+
+def _run_subprocess(
+    command: list[str],
+    cancellation: GenerationCancellationContext | None = None,
+) -> subprocess.CompletedProcess[str]:
+    _raise_if_cancelled(cancellation)
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    handle = ProcessHandle(_proc=process)
+    if cancellation is not None:
+        cancellation.register(handle)
+        if cancellation.cancel_requested:
+            process.kill()
+    try:
+        stdout, stderr = process.communicate()
+    finally:
+        if cancellation is not None:
+            cancellation.unregister(handle)
+    _raise_if_cancelled(cancellation)
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode, command, output=stdout, stderr=stderr)
+    return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+
+
+def parse_srt_transcript(content: str) -> Transcript:
+    """将非空 SRT 文本转换为按时间排序的中文 ``Transcript``。"""
+    subtitles = list(srt.parse(content))
+    segments = [
+        TranscriptSegment(
+            start_seconds=item.start.total_seconds(),
+            end_seconds=item.end.total_seconds(),
+            text=item.content.strip(),
+        )
+        for item in subtitles
+        if item.content.strip() and item.end > item.start
+    ]
+    if not segments:
+        raise ValueError("字幕中没有有效时间片段。")
+    return Transcript(language="zh", segments=segments)
+
+
+def _discard_ytdlp_screen_output(*args: object, **kwargs: object) -> None:
+    """字幕枚举是内部步骤，不向后端 stdout 输出 yt-dlp 的轨道表。"""
+
+
+def _raise_if_cancelled(cancellation: GenerationCancellationContext | None) -> None:
+    if cancellation is not None and cancellation.cancel_requested:
+        raise InterruptedError("任务已取消")

--- a/tests/backend/unit/generation/test_generate_summary_subtitles.py
+++ b/tests/backend/unit/generation/test_generate_summary_subtitles.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from backend.video_summary.domain.models import SummaryDocument, Transcript, TranscriptSegment
+from backend.video_summary.generation.usecases.generate_summary import GenerateVideoSummary
+
+
+class _SubtitleSource:
+    cache_identity = "test-subtitles"
+
+    def load(self, video_path: Path, staging_dir: Path, cancellation=None) -> Transcript:
+        return Transcript(
+            language="zh",
+            segments=[TranscriptSegment(0.0, 3.0, "使用字幕，不使用 ASR")],
+        )
+
+
+class _MediaProcessor:
+    def probe_duration(self, video_path: Path) -> float:
+        raise AssertionError("字幕命中时不应探测媒体时长")
+
+    def extract_audio(self, video_path: Path, audio_path: Path, cancellation=None) -> Path:
+        raise AssertionError("字幕命中时不应抽取音频")
+
+
+class _Transcriber:
+    def transcribe(self, audio_path: Path, output_stem: Path, on_progress=None) -> Transcript:
+        raise AssertionError("字幕命中时不应调用 ASR")
+
+
+class _ArtifactStore:
+    async def save_cleaned_transcript(self, *, video, transcript, output_dir) -> None:
+        self.transcript = transcript
+
+    async def save_enhanced_transcript(self, *, transcript, output_dir) -> None:
+        self.enhanced_transcript = transcript
+
+    async def save_summary_document(self, *, document, output_dir) -> None:
+        pass
+
+
+class _Enhancer:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def enhance(self, video, transcript, cancellation=None) -> Transcript:
+        self.calls += 1
+        return Transcript(
+            language=transcript.language,
+            segments=[TranscriptSegment(0.0, 3.0, f"增强：{transcript.full_text}")],
+        )
+
+
+class _Summarizer:
+    async def summarize(self, video, transcript, cancellation=None) -> SummaryDocument:
+        assert video.duration_seconds == 3.0
+        return SummaryDocument(markdown="# summary", summary_data={})
+
+
+class GenerateVideoSummarySubtitleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_subtitle_transcript_skips_media_and_asr(self) -> None:
+        store = _ArtifactStore()
+        use_case = GenerateVideoSummary(
+            media_processor=_MediaProcessor(),
+            transcriber=_Transcriber(),
+            transcript_enhancer=None,
+            summarizer=_Summarizer(),
+            artifact_store=store,
+            subtitle_provider=_SubtitleSource(),
+        )
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            await use_case.run(root / "video.mp4", root / "output")
+        assert store.transcript.full_text == "使用字幕，不使用 ASR"
+
+    async def test_subtitle_transcript_can_be_enhanced(self) -> None:
+        store = _ArtifactStore()
+        enhancer = _Enhancer()
+        use_case = GenerateVideoSummary(
+            media_processor=_MediaProcessor(),
+            transcriber=_Transcriber(),
+            transcript_enhancer=enhancer,
+            summarizer=_Summarizer(),
+            artifact_store=store,
+            subtitle_provider=_SubtitleSource(),
+        )
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            video_path = root / "video.mp4"
+            video_path.write_text("video", encoding="utf-8")
+            await use_case.run(video_path, root / "output")
+
+        assert enhancer.calls == 1
+        assert store.enhanced_transcript.full_text == "增强：使用字幕，不使用 ASR"
+        assert store.transcript.full_text == "增强：使用字幕，不使用 ASR"

--- a/tests/backend/unit/infrastructure/test_subtitle_transcripts.py
+++ b/tests/backend/unit/infrastructure/test_subtitle_transcripts.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.video_summary.generation.cancellation import GenerationCancellationContext
+from backend.video_summary.infrastructure.subtitle_transcripts import SubtitleTranscriptProvider
+
+
+_SRT = """1
+00:00:00,000 --> 00:00:01,500
+简体中文字幕
+
+"""
+
+
+def test_bilibili_ai_zh_subtitle_is_selected(monkeypatch, tmp_path: Path) -> None:
+    class FakeYoutubeDL:
+        def __init__(self, options: dict[str, object]) -> None:
+            assert options["listsubtitles"] is True
+
+        def __enter__(self) -> "FakeYoutubeDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool) -> dict[str, object]:
+            assert "BV1vJ3P6KEkh" in url
+            return {
+                "subtitles": {
+                    "ai-en": [{"ext": "srt", "data": _SRT.replace("简体中文", "English")}],
+                    "ai-zh": [{"ext": "srt", "data": _SRT}],
+                }
+            }
+
+    monkeypatch.setattr("yt_dlp.YoutubeDL", FakeYoutubeDL)
+    monkeypatch.setattr(
+        "backend.video_summary.infrastructure.subtitle_transcripts._load_embedded_subtitle",
+        lambda video_path, output_path, cancellation=None: None,
+    )
+    transcript = SubtitleTranscriptProvider().load(tmp_path / "BV1vJ3P6KEkh.mp4", tmp_path)
+
+    assert transcript is not None
+    assert transcript.language == "zh"
+    assert transcript.full_text == "简体中文字幕"
+
+
+def test_bilibili_non_chinese_subtitles_are_rejected(monkeypatch, tmp_path: Path) -> None:
+    class FakeYoutubeDL:
+        def __init__(self, options: dict[str, object]) -> None:
+            pass
+
+        def __enter__(self) -> "FakeYoutubeDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool) -> dict[str, object]:
+            return {"subtitles": {"ai-en": [{"ext": "srt", "data": _SRT}]}}
+
+    monkeypatch.setattr("yt_dlp.YoutubeDL", FakeYoutubeDL)
+    monkeypatch.setattr(
+        "backend.video_summary.infrastructure.subtitle_transcripts._load_embedded_subtitle",
+        lambda video_path, output_path, cancellation=None: None,
+    )
+    transcript = SubtitleTranscriptProvider().load(tmp_path / "BV1NoTk6SERz.mp4", tmp_path)
+
+    assert transcript is None
+
+
+def test_embedded_chinese_text_subtitle_is_exported(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], cancellation=None) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[0] == "ffprobe":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                '{"streams":[{"index":2,"codec_type":"subtitle","codec_name":"mov_text","tags":{"language":"zh-Hans"}}]}',
+                "",
+            )
+        Path(command[-1]).write_text(_SRT, encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr("backend.video_summary.infrastructure.subtitle_transcripts._run_subprocess", fake_run)
+    transcript = SubtitleTranscriptProvider().load(tmp_path / "local.mp4", tmp_path)
+
+    assert transcript is not None
+    assert transcript.full_text == "简体中文字幕"
+    assert calls[1][calls[1].index("-map") + 1] == "0:2"
+
+
+def test_embedded_non_chinese_subtitle_is_rejected(monkeypatch, tmp_path: Path) -> None:
+    def fake_run(command: list[str], cancellation=None) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            '{"streams":[{"index":2,"codec_type":"subtitle","codec_name":"mov_text","tags":{"language":"en"}}]}',
+            "",
+        )
+
+    monkeypatch.setattr("backend.video_summary.infrastructure.subtitle_transcripts._run_subprocess", fake_run)
+    assert SubtitleTranscriptProvider().load(tmp_path / "local.mp4", tmp_path) is None
+
+
+def test_embedded_subtitle_subprocess_is_cancelled(monkeypatch) -> None:
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.returncode = -9
+            self.killed = False
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def communicate(self) -> tuple[str, str]:
+            cancellation.request_cancel()
+            return "", ""
+
+    cancellation = GenerationCancellationContext("subtitle-test")
+    process = FakeProcess()
+
+    monkeypatch.setattr(
+        "backend.video_summary.infrastructure.subtitle_transcripts.subprocess.Popen",
+        lambda *args, **kwargs: process,
+    )
+
+    from backend.video_summary.infrastructure.subtitle_transcripts import _run_subprocess
+
+    with pytest.raises(InterruptedError):
+        _run_subprocess(["ffprobe", "-version"], cancellation)
+
+    assert process.killed is True


### PR DESCRIPTION
## Summary
- add subtitle-first transcript source for Bilibili and embedded text subtitles
- skip audio extraction/ASR when usable Chinese subtitles are available
- share Bilibili yt-dlp header/cookie/proxy helpers without creating backend package cycles
- wire cancellation into subtitle probing/extraction and cover subtitle + enhancer/cache paths

## Verification
- `python -m pytest tests/backend/unit/generation/test_generate_summary_cancellation.py tests/backend/unit/generation/test_generate_summary_subtitles.py tests/backend/unit/infrastructure/test_subtitle_transcripts.py tests/backend/unit/bilibili/test_ytdlp_bilibili.py -q`
- `$env:PYTHONPATH='src'; lint-imports --config .importlinter`
- Manual MCP smoke test with `BV1Yx3468ENd`: `probe_subtitles` -> `extract_subtitles` -> `summarize`, no `extract_audio` / `transcribe`

Closes #57